### PR TITLE
Fixes block detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ having the comments modified in a `javadoc.jar` or a Dokka HTML website.
 
 Note: `{@inline tags}` work in KDoc comments too! Plus, `{@tags {@inside tags}}` work too.
 
-The processing order is:
+The processing order per processor is:
 
 - Inline tags
     - depth-first
@@ -381,30 +381,32 @@ For example, the following KDoc:
  * @a [Test2]
  * Hi there!
  * @b source someFun
- * Some more text. (
- * @c [Test1] {
- * )
+ * Some more text. {@c
+ * @d [Test1] (
+ * }
+ * @e)
  */
 ```
 
-will be parsed as follows:
+will be split up in blocks as follows:
 
 ```
 [
   "\nSome extra text",
   "@a [Test2]\nHi there!",
-  "@b source someFun\nSome more text. (\n@c [Test1] {\n)\n",
+  "@b source someFun\nSome more text. (\n{@c [Test1] (\n}",
+  "@e)\n",
 ]
 ```
 
-This is also how tag processors receive their data. Note that any newlines after the `@tag`
+This is also how tag processors receive their block-data. Note that any newlines after the `@tag`
 are also included as part of the tag data. Tag processors can then decide what to do with this extra data.
 However, `@include`, `@getArg`, `@sample`, and `@includeFile` all have systems in place that
 will keep the content after the tag and on the lines below the tag in place.
 Take this into account when writing your own processors.
 
 To avoid any confusion, it's usually easier to stick to `{@inline tags}` as then it's clear which part of the doc
-belongs to the tag and what does not. Inline tags are processed before block tags.
+belongs to the tag and what does not. Inline tags are processed before block tags per processor.
 
 Take extra care when using tags that can introduce new tags, such as `@include`, as this will cause the structure
 of the doc to change mid-processing. Very powerful, but also potentially dangerous.

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/docUtils.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/docUtils.kt
@@ -210,9 +210,9 @@ fun DocContent.getTagNameOrNull(): String? =
 
 /**
  * Split doc content in blocks of content and text belonging to tags.
- * The tag, if present, can be found with optional leading spaces in the first line of the block.
+ * The tag, if present, can be found with optional (up to max 2) leading spaces in the first line of the block.
  * You can get the name with [String.getTagNameOrNull].
- * Splitting takes `{}`, `[]`, `()`, and triple backticks into account.
+ * Splitting takes triple backticks and `{@..}` into account.
  * Block "marks" are ignored if "\" escaped.
  * Can be joint with '\n' to get the original content.
  */
@@ -220,6 +220,11 @@ fun DocContent.splitDocContentPerBlock(): List<DocContent> {
     val docContent = this@splitDocContentPerBlock.split('\n')
     return buildList {
         var currentBlock = ""
+
+        /**
+         * keeps track of the current blocks
+         * denoting `{@..}` with [CURLY_BRACES] and triple "`" with [BACKTICKS]
+         */
         val blocksIndicators = mutableListOf<Char>()
 
         fun isInCodeBlock() = BACKTICKS in blocksIndicators
@@ -227,46 +232,54 @@ fun DocContent.splitDocContentPerBlock(): List<DocContent> {
         for (line in docContent) {
 
             // start a new block if the line starts with a tag and we're not
-            // in a {} or `````` block
-            if (line.trimStart().startsWith("@") && blocksIndicators.isEmpty()) {
-                if (currentBlock.isNotEmpty()) add(currentBlock.removeSuffix("\n"))
-                currentBlock = "$line\n"
-            } else if (line.isEmpty() && blocksIndicators.isEmpty()) {
-                currentBlock += "\n"
-            } else {
-                if (currentBlock.isEmpty()) {
+            // in a {@..} or ```..``` block
+            val lineStartsWithTag = line
+                .removePrefix(" ")
+                .removePrefix(" ")
+                .startsWith("@")
+
+            when {
+                // start a new block if the line starts with a tag and we're not in a {@..} or ```..``` block
+                lineStartsWithTag && blocksIndicators.isEmpty() -> {
+                    if (currentBlock.isNotEmpty())
+                        this += currentBlock.removeSuffix("\n")
                     currentBlock = "$line\n"
-                } else {
-                    currentBlock += "$line\n"
+                }
+
+                line.isEmpty() && blocksIndicators.isEmpty() -> {
+                    currentBlock += "\n"
+                }
+
+                else -> {
+                    if (currentBlock.isEmpty()) {
+                        currentBlock = "$line\n"
+                    } else {
+                        currentBlock += "$line\n"
+                    }
                 }
             }
             var escapeNext = false
-            for (char in line) {
+            for ((i, char) in line.withIndex()) {
+                when {
+                    escapeNext -> {
+                        escapeNext = false
+                        continue
+                    }
 
-                if (escapeNext) {
-                    escapeNext = false
-                    continue
+                    char == '\\' ->
+                        escapeNext = true
+
+                    // ``` detection
+                    char == '`' && line.getOrNull(i + 1) == '`' && line.getOrNull(i + 2) == '`' ->
+                        if (!blocksIndicators.removeAllElementsFromLast(BACKTICKS)) blocksIndicators += BACKTICKS
                 }
+                if (isInCodeBlock()) continue
+                when {
+                    char == '{' && line.getOrNull(i + 1) == '@' ->
+                        blocksIndicators += CURLY_BRACES
 
-                when (char) {
-                    '\\' -> escapeNext = true
-
-                    '`' -> if (!blocksIndicators.removeAllElementsFromLast(BACKTICKS)) blocksIndicators += BACKTICKS
-                }
-                if (!isInCodeBlock()) when (char) {
-                    '{' -> blocksIndicators += CURLY_BRACES
-                    '}' -> blocksIndicators.removeAllElementsFromLast(CURLY_BRACES)
-
-                    '[' -> blocksIndicators += SQUARE_BRACKETS
-                    ']' -> blocksIndicators.removeAllElementsFromLast(SQUARE_BRACKETS)
-
-                    '(' -> blocksIndicators += PARENTHESES
-                    ')' -> blocksIndicators.removeAllElementsFromLast(PARENTHESES)
-
-                    '<' -> blocksIndicators += ANGULAR_BRACKETS
-                    '>' -> blocksIndicators.removeAllElementsFromLast(ANGULAR_BRACKETS)
-
-                    // TODO: issue #11: html tags
+                    char == '}' ->
+                        blocksIndicators.removeAllElementsFromLast(CURLY_BRACES)
                 }
             }
         }

--- a/doc-processor-common/src/test/kotlin/nl/jolanrensen/docProcessor/TestFindingTagsInDocs.kt
+++ b/doc-processor-common/src/test/kotlin/nl/jolanrensen/docProcessor/TestFindingTagsInDocs.kt
@@ -92,8 +92,8 @@ class TestFindingTagsInDocs {
 
     @Test
     fun `Find tag after difficult doc content`() {
-        val expectedInline = setOf("includeArg")
-        val expectedBlock = setOf("param", "return", "arg", "see")
+        val expectedInline = setOf("getArg")
+        val expectedBlock = setOf("param", "return", "setArg", "see")
         val kdoc1 = """
             ## Cols
             Creates a subset of columns ([ColumnSet][org.jetbrains.kotlinx.dataframe.columns.ColumnSet]) from a parent [ColumnSet][org.jetbrains.kotlinx.dataframe.columns.ColumnSet], -[ColumnGroup][org.jetbrains.kotlinx.dataframe.columns.ColumnGroup], or -[DataFrame][org.jetbrains.kotlinx.dataframe.DataFrame].
@@ -133,8 +133,8 @@ class TestFindingTagsInDocs {
             
         """.trimIndent()
 
-//        kdoc1.findInlineTagNamesInDocContent().toSet() shouldBe expectedInline
-//        kdoc1.findBlockTagNamesInDocContent().toSet() shouldBe expectedBlock
+        kdoc1.findInlineTagNamesInDocContent().toSet() shouldBe expectedInline
+        kdoc1.findBlockTagNamesInDocContent().toSet() shouldBe expectedBlock
         println(kdoc1.splitDocContentPerBlock().joinToString("\n.............................................\n"))
     }
 


### PR DESCRIPTION
Fixes https://github.com/Jolanrensen/docProcessorGradlePlugin/issues/31.

Doc content is now always split by block if the line starts (prepending at most 2 spaces) with `@`, unless inside ` ```..``` ` or `{@..}`.

