### PR TITLE
Performance by Include dependency graph

### DIFF
--- a/doc-processor-common/build.gradle.kts
+++ b/doc-processor-common/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.apache.commons:commons-text:1.10.0")
 
     implementation("org.jetbrains:markdown-jvm:0.6.1")
+    api("org.jgrapht:jgrapht-core:1.5.2")
     
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1-Beta")
 

--- a/doc-processor-common/build.gradle.kts
+++ b/doc-processor-common/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "nl.jolanrensen.docProcessor"
-version = "0.3.4-SNAPSHOT"
+version = "0.3.5-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/doc-processor-common/build.gradle.kts
+++ b/doc-processor-common/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation("org.apache.commons:commons-text:1.10.0")
 
     implementation("org.jetbrains:markdown-jvm:0.6.1")
+    
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1-Beta")
 
     // logging
     api("io.github.microutils:kotlin-logging:3.0.5")

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocAnalyser.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocAnalyser.kt
@@ -1,0 +1,21 @@
+package nl.jolanrensen.docProcessor
+
+/**
+ * Same as [DocProcessor] but without the ability to modify docs.
+ */
+abstract class DocAnalyser<out R> : DocProcessor() {
+
+    abstract fun getAnalyzedResult(): R
+
+    protected abstract fun analyze(processLimit: Int, documentablesByPath: DocumentablesByPath)
+
+    fun analyzeSafely(processLimit: Int, documentablesByPath: DocumentablesByPath): DocAnalyser<R> {
+        processSafely(processLimit, documentablesByPath)
+        return this
+    }
+
+    final override fun process(processLimit: Int, documentablesByPath: DocumentablesByPath): DocumentablesByPath {
+        analyze(processLimit, documentablesByPath)
+        return documentablesByPath
+    }
+}

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocProcessor.kt
@@ -38,13 +38,13 @@ abstract class DocProcessor : Serializable {
      * @param documentablesByPath Documentables by path
      * @return modified docs by path
      */
-    abstract fun process(
+    protected abstract fun process(
         processLimit: Int,
         documentablesByPath: DocumentablesByPath,
     ): DocumentablesByPath
 
     // ensuring each doc processor instance is only run once
-    private var hasRun = false
+    protected var hasRun = false
 
     // ensuring each doc processor instance is only run once
     @Throws(DocProcessorFailedException::class)
@@ -83,7 +83,7 @@ fun findProcessors(fullyQualifiedNames: List<String>, arguments: Map<String, Any
         }.map {
             // create a new instance of the processor, so it can safely be used multiple times
             // also pass on the arguments
-            it::class.java.newInstance()
+            it::class.java.getDeclaredConstructor().newInstance()
                 .also { it.arguments = arguments }
         }
 

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapper.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapper.kt
@@ -61,19 +61,35 @@ open class DocumentableWrapper(
     val file: File,
     val docFileTextRange: IntRange,
     val docIndent: Int,
-    val identifier: UUID = UUID.randomUUID(),
     val annotations: List<AnnotationWrapper>,
     val fileTextRange: IntRange,
+    val identifier: UUID = computeIdentifier(fullyQualifiedPath, fullyQualifiedExtensionPath, fileTextRange.first),
 
     open val docContent: DocContent,
     open val tags: Set<String>,
     open val isModified: Boolean,
+    open val dependsOn: List<DocumentableWrapper>,
 
     open val htmlRangeStart: Int?,
     open val htmlRangeEnd: Int?,
 ) {
 
-    companion object;
+    companion object {
+
+        /**
+         * Computes a unique identifier for a documentable based on its [fullyQualifiedPath] and
+         * its [fullyQualifiedExtensionPath].
+         */
+        fun computeIdentifier(
+            fullyQualifiedPath: String,
+            fullyQualifiedExtensionPath: String?,
+            textRangeStart: Int,
+        ): UUID = UUID.nameUUIDFromBytes(
+            listOf(fullyQualifiedPath, fullyQualifiedExtensionPath, textRangeStart)
+                .joinToString()
+                .toByteArray()
+        )
+    }
 
     constructor(
         docContent: DocContent,
@@ -88,6 +104,7 @@ open class DocumentableWrapper(
         docIndent: Int,
         annotations: List<AnnotationWrapper>,
         fileTextRange: IntRange,
+        dependsOn: List<DocumentableWrapper>,
         htmlRangeStart: Int? = null,
         htmlRangeEnd: Int? = null,
     ) : this(
@@ -104,6 +121,7 @@ open class DocumentableWrapper(
         docIndent = docIndent,
         docContent = docContent,
         annotations = annotations,
+        dependsOn = dependsOn,
         tags = docContent.findTagNamesInDocContent().toSet(),
         isModified = false,
         htmlRangeStart = htmlRangeStart,
@@ -298,6 +316,8 @@ open class DocumentableWrapper(
         return lines.subList(start, end + 1).joinToString("\n")
     }
 
+    fun getDocContentHashcode(): Int = docContent.hashCode()
+
     /** Returns a copy of this [DocumentableWrapper] with the given parameters. */
     open fun copy(
         docContent: DocContent = this.docContent,
@@ -321,6 +341,7 @@ open class DocumentableWrapper(
             annotations = annotations,
             identifier = identifier,
             fileTextRange = fileTextRange,
+            dependsOn = dependsOn,
             htmlRangeStart = htmlRangeStart,
             htmlRangeEnd = htmlRangeEnd,
         )

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapper.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapper.kt
@@ -74,7 +74,6 @@ open class DocumentableWrapper(
     open val docContent: DocContent,
     open val tags: Set<String>,
     open val isModified: Boolean,
-    open val dependsOn: List<DocumentableWrapper>,
 
     open val htmlRangeStart: Int?,
     open val htmlRangeEnd: Int?,
@@ -114,7 +113,6 @@ open class DocumentableWrapper(
         docIndent: Int,
         annotations: List<AnnotationWrapper>,
         fileTextRange: IntRange,
-        dependsOn: List<DocumentableWrapper> = emptyList(),
         htmlRangeStart: Int? = null,
         htmlRangeEnd: Int? = null,
     ) : this(
@@ -131,7 +129,6 @@ open class DocumentableWrapper(
         docIndent = docIndent,
         docContent = docContent,
         annotations = annotations,
-        dependsOn = dependsOn,
         tags = docContent.findTagNamesInDocContent().toSet(),
         isModified = false,
         htmlRangeStart = htmlRangeStart,
@@ -245,12 +242,16 @@ open class DocumentableWrapper(
      * Queries the [documentables] map for a [DocumentableWrapper] that exists for
      * the given [query].
      * Returns `null` if no [DocumentableWrapper] is found for the given [query].
+     *
+     * @param canBeCache Whether the query can be a cache or not. Mosty only used by the
+     *   IntelliJ plugin and [IncludeDocProcessor].
      */
     fun queryDocumentables(
         query: String,
         documentablesNoFilters: DocumentablesByPath,
         documentables: DocumentablesByPath,
         canBeExtension: Boolean = true,
+        canBeCache: Boolean = false,
         filter: (DocumentableWrapper) -> Boolean = { true },
     ): DocumentableWrapper? {
         val queries = getAllFullPathsFromHereForTargetPath(
@@ -271,7 +272,10 @@ open class DocumentableWrapper(
         }
 
         return queries.firstNotNullOfOrNull {
-            documentables[it]?.firstOrNull(filter)
+            documentables.query(
+                path = it,
+                canBeCache = canBeCache,
+            )?.firstOrNull(filter)
         }
     }
 
@@ -349,7 +353,6 @@ open class DocumentableWrapper(
         annotations = annotations,
         identifier = identifier,
         fileTextRange = fileTextRange,
-        dependsOn = dependsOn,
         htmlRangeStart = htmlRangeStart,
         htmlRangeEnd = htmlRangeEnd,
     )

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPath.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPath.kt
@@ -3,8 +3,9 @@ package nl.jolanrensen.docProcessor
 import java.util.*
 
 typealias DocumentableWrapperFilter = (DocumentableWrapper) -> Boolean
+
 @Suppress("ClassName")
-internal data object NO_FILTER: DocumentableWrapperFilter {
+internal data object NO_FILTER : DocumentableWrapperFilter {
     override fun invoke(p1: DocumentableWrapper): Boolean = true
 
 }
@@ -26,9 +27,9 @@ interface DocumentablesByPath {
      * Returns `null` if no [DocumentableWrapper] is found for the given [path] and [path]
      * does not exist in the project.
      */
-    fun query(path: String): List<DocumentableWrapper>?
+    fun query(path: String, canBeCache: Boolean = false): List<DocumentableWrapper>?
 
-    operator fun get(path: String): List<DocumentableWrapper>? = query(path)
+    operator fun get(path: String, canBeCache: Boolean = false): List<DocumentableWrapper>? = query(path, canBeCache)
 
     operator fun get(identifier: UUID): DocumentableWrapper? =
         documentablesToProcess
@@ -57,9 +58,13 @@ interface DocumentablesByPath {
 
 interface MutableDocumentablesByPath : DocumentablesByPath {
 
-    override fun query(path: String): List<MutableDocumentableWrapper>?
+    override fun query(path: String, canBeCache: Boolean): List<MutableDocumentableWrapper>?
 
-    override operator fun get(path: String): List<MutableDocumentableWrapper>? = query(path)
+    override operator fun get(path: String, canBeCache: Boolean): List<MutableDocumentableWrapper>? = query(path)
+
+    override operator fun get(identifier: UUID): MutableDocumentableWrapper? =
+        documentablesToProcess.values
+            .firstNotNullOfOrNull { it.firstOrNull { it.identifier == identifier } }
 
     override fun withQueryFilter(queryFilter: DocumentableWrapperFilter): MutableDocumentablesByPath
 

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPath.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPath.kt
@@ -3,7 +3,11 @@ package nl.jolanrensen.docProcessor
 import java.util.*
 
 typealias DocumentableWrapperFilter = (DocumentableWrapper) -> Boolean
-internal val NO_FILTER: DocumentableWrapperFilter = { true }
+@Suppress("ClassName")
+internal data object NO_FILTER: DocumentableWrapperFilter {
+    override fun invoke(p1: DocumentableWrapper): Boolean = true
+
+}
 
 interface DocumentablesByPath {
 

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPathFromMap.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPathFromMap.kt
@@ -22,7 +22,7 @@ open class DocumentablesByPathFromMap(
             }
         }
 
-    override fun query(path: String): List<DocumentableWrapper>? = docsToQuery[path]
+    override fun query(path: String, canBeCache: Boolean): List<DocumentableWrapper>? = docsToQuery[path]
 
     override fun toMutable(): MutableDocumentablesByPath =
         this as? MutableDocumentablesByPath ?: MutableDocumentablesByPathFromMap(
@@ -87,7 +87,7 @@ class MutableDocumentablesByPathFromMap(
             }
         }
 
-    override fun query(path: String): List<MutableDocumentableWrapper>? = docsToQuery[path]
+    override fun query(path: String, canBeCache: Boolean): List<MutableDocumentableWrapper>? = docsToQuery[path]
 
     override fun toMutable(): MutableDocumentablesByPath = this
 

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPathFromMap.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPathFromMap.kt
@@ -6,6 +6,8 @@ open class DocumentablesByPathFromMap(
     final override val documentablesToProcessFilter: DocumentableWrapperFilter = NO_FILTER,
 ) : DocumentablesByPath {
 
+    override val needToQueryAllPaths: Boolean = true
+
     override val documentablesToProcess: Map<String, List<DocumentableWrapper>> =
         when (documentablesToProcessFilter) {
             NO_FILTER -> allDocs
@@ -22,7 +24,11 @@ open class DocumentablesByPathFromMap(
             }
         }
 
-    override fun query(path: String, canBeCache: Boolean): List<DocumentableWrapper>? = docsToQuery[path]
+    override fun query(
+        path: String,
+        queryContext: DocumentableWrapper,
+        canBeCache: Boolean,
+    ): List<DocumentableWrapper>? = docsToQuery[path]
 
     override fun toMutable(): MutableDocumentablesByPath =
         this as? MutableDocumentablesByPath ?: MutableDocumentablesByPathFromMap(
@@ -71,6 +77,8 @@ class MutableDocumentablesByPathFromMap(
     override val documentablesToProcessFilter: DocumentableWrapperFilter = NO_FILTER,
 ) : MutableDocumentablesByPath {
 
+    override val needToQueryAllPaths: Boolean = true
+
     override val documentablesToProcess: Map<String, List<MutableDocumentableWrapper>> =
         when (documentablesToProcessFilter) {
             NO_FILTER -> allDocs
@@ -87,7 +95,11 @@ class MutableDocumentablesByPathFromMap(
             }
         }
 
-    override fun query(path: String, canBeCache: Boolean): List<MutableDocumentableWrapper>? = docsToQuery[path]
+    override fun query(
+        path: String,
+        queryContext: DocumentableWrapper,
+        canBeCache: Boolean,
+    ): List<MutableDocumentableWrapper>? = docsToQuery[path]
 
     override fun toMutable(): MutableDocumentablesByPath = this
 

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPathWithCache.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentablesByPathWithCache.kt
@@ -1,10 +1,14 @@
 package nl.jolanrensen.docProcessor
 
+import nl.jolanrensen.docProcessor.defaultProcessors.IncludeDocAnalyzer
 import org.jgrapht.graph.SimpleDirectedGraph
+import org.jgrapht.traverse.BreadthFirstIterator
+import org.jgrapht.traverse.TopologicalOrderIterator
 import java.util.*
 
 
 open class DocumentablesByPathWithCache<C>(
+    val processLimit: Int,
     val queryNew: (context: C, link: String) -> List<DocumentableWrapper>?,
 ) : DocumentablesByPath, MutableDocumentablesByPath {
 
@@ -13,150 +17,190 @@ open class DocumentablesByPathWithCache<C>(
     override var documentablesToProcessFilter: DocumentableWrapperFilter = NO_FILTER
 
     // graph representing the dependencies between documentables
-    private val dependencyGraph = SimpleDirectedGraph<UUID, _>(Edge::class.java as Class<out Edge<UUID>>)
-
-    // holds previous query results
-    private val fqNamesCache: MutableMap<UUID, Pair<String, String?>> = mutableMapOf()
-
-    // todo, also track imports, superPaths, now done by UUID, but
-    // todo might revert back to keep docContent
+    private var dependencyGraph = SimpleDirectedGraph<UUID, _>(Edge::class.java as Class<out Edge<UUID>>)
 
     // holds the hashcodes of the source of the documentables, to be updated each time a documentable is queried
     private val docContentSourceHashCodeCache: MutableMap<UUID, Int> = mutableMapOf()
 
     // holds the resulting docs of the documentables, to be updated each time a documentable has been processed
     // Can be deleted if needsRebuild is true
+    // cannot be used in query(), see postIncludeDocContentCache instead
     private val docContentResultCache: MutableMap<UUID, String> = mutableMapOf()
+
+    // holds the intermediate (post-@include) docContent states of the docs
+    // this is used on query
+    private val postIncludeDocContentCache: MutableMap<UUID, String> = mutableMapOf()
 
     private var context: C? = null
     private var docToProcess: MutableDocumentableWrapper? = null
-        set(value) {
-            field = value
-
-            docsToProcess = docToProcess?.let { docToProcess ->
-                listOfNotNull(
-                    docToProcess.fullyQualifiedPath,
-                    docToProcess.fullyQualifiedExtensionPath,
-                ).associateWith { listOf(docToProcess) }
-            } ?: emptyMap()
-        }
-
-    private var docsToProcess: Map<String, List<MutableDocumentableWrapper>> = emptyMap()
+    private var docsToProcess: MutableMap<String, MutableList<MutableDocumentableWrapper>> = mutableMapOf()
+    private var queryCache: MutableMap<String, MutableList<MutableDocumentableWrapper>> = mutableMapOf()
 
     override val documentablesToProcess: Map<String, List<MutableDocumentableWrapper>>
         get() = when {
             docToProcess == null -> emptyMap()
-            documentablesToProcessFilter == NO_FILTER ||
-                    documentablesToProcessFilter(docToProcess!!) -> docsToProcess
-
-            else -> emptyMap()
+            documentablesToProcessFilter == NO_FILTER -> docsToProcess
+            else -> docsToProcess.mapValues { (_, documentables) ->
+                documentables.filter(documentablesToProcessFilter)
+            }
         }
 
     fun getDocContentResult(docId: UUID): String? = docContentResultCache[docId]
 
-    // we set a context and a documentable to process
-    fun updatePreProcessing(context: C, docToProcess: DocumentableWrapper) {
-        this.context = context
-        this.docToProcess = docToProcess.toMutable()
-
-        fqNamesCache[docToProcess.identifier] = Pair(docToProcess.fullyQualifiedPath, docToProcess.fullyQualifiedExtensionPath)
+    /**
+     * called from [nl.jolanrensen.docProcessor.services.PostIncludeDocProcessorCacheCollector]
+     */
+    fun updatePostIncludeDocContentResult(documentable: DocumentableWrapper) {
+        postIncludeDocContentCache[documentable.identifier] = documentable.docContent
     }
 
-    override fun query(path: String): List<MutableDocumentableWrapper>? {
+    // we set a context and a documentable to process
+    // returns whether it needs a rebuild
+    fun updatePreProcessing(context: C, docToProcess: DocumentableWrapper): Boolean {
+        val doc = docToProcess.toMutable()
+        this.context = context
+        this.docToProcess = doc
+        this.docsToProcess = listOfNotNull(doc.fullyQualifiedPath, doc.fullyQualifiedExtensionPath)
+            .associateWith { mutableListOf(doc) }
+            .toMutableMap()
+
+        this.queryCache = mutableMapOf()
+
+        // build local dependency graph from docToProcess and update the global dependencyGraph
+        val graph = IncludeDocAnalyzer.getAnalyzedResult(
+            processLimit = processLimit,
+            documentablesByPath = this,
+            analyzeQueriesToo = true,
+        )
+        for (vertex in graph.vertexSet()) {
+            if (!dependencyGraph.containsVertex(vertex.identifier))
+                dependencyGraph.addVertex(vertex.identifier)
+
+            val oldIncomingEdges = dependencyGraph.incomingEdgesOf(vertex.identifier)
+            val newIncomingEdges = graph.incomingEdgesOf(vertex).map {
+                Edge(it.from.identifier, it.to.identifier)
+            }.toSet()
+
+            for (newEdge in (newIncomingEdges - oldIncomingEdges)) {
+                dependencyGraph.addVertex(newEdge.from)
+                dependencyGraph.addVertex(newEdge.to)
+                dependencyGraph.addEdge(newEdge.from, newEdge.to, newEdge)
+            }
+            for (removedEdge in (oldIncomingEdges - newIncomingEdges)) {
+                dependencyGraph.removeEdge(removedEdge)
+            }
+        }
+
+        // graph may not contain doc if it has no dependencies, so add it to the list
+        val orderedList = TopologicalOrderIterator(graph).asSequence().toList()
+            .let { if (doc !in it) it + doc else it }
+
+        // rebuild docsToProcess, this time ordered and with dependent docs for PostIncludeDocProcessor that are not
+        // up to date. Also update query cache
+        for (dependencyDoc in orderedList) {
+
+            // put doc into query cache
+            listOfNotNull(dependencyDoc.fullyQualifiedPath, dependencyDoc.fullyQualifiedExtensionPath)
+                .forEach {
+                    queryCache.getOrPut(it) { mutableListOf() }.add(dependencyDoc.toMutable())
+                }
+        }
+
+        var needsRebuild = false
+        for (dependencyDoc in orderedList) {
+            val mutable = dependencyDoc.toMutable()
+
+            // put doc into process queue if it needs a rebuild
+            if (needsRebuild(dependencyDoc)) {
+                needsRebuild = true
+                listOfNotNull(dependencyDoc.fullyQualifiedPath, dependencyDoc.fullyQualifiedExtensionPath)
+                    .forEach {
+                        docsToProcess.getOrPut(it) { mutableListOf() }.add(mutable)
+                    }
+            }
+        }
+
+        return needsRebuild
+    }
+
+    // retrieve a doc by identifier from queryCache or docsToProcess
+    override fun get(identifier: UUID): MutableDocumentableWrapper? =
+        queryCache.values
+            .firstNotNullOfOrNull { it.firstOrNull { it.identifier == identifier } }
+            ?: super<MutableDocumentablesByPath>.get(identifier)
+
+
+    override fun query(path: String, canBeCache: Boolean): List<MutableDocumentableWrapper>? {
         require(context != null) { "updatePreProcessing must be called before query" }
-        val queryRes = queryNew(context!!, path)
-            ?.map { it.toMutable() }
+        val res = queryCache.getOrPut(path) {
+            queryNew(context!!, path)
+                ?.filter(queryFilter)
+                ?.map { it.toMutable() }
+                ?.toMutableList()
+                ?: return@query null
+        }
 
         // load cached results directly into queries
-        // actually, we can't. The final documentable can override get/set args
-        // can be done with @include
-//        queryRes?.forEach {
-//            val needsRebuild = needsRebuild(it)
-//            val docContentResult = getDocContentResult(it.identifier)
-//            if (!needsRebuild && docContentResult != null) {
-//                it.modifyDocContentAndUpdate(docContentResult)
-//                println("loading cached ${it.fullyQualifiedPath}/${it.fullyQualifiedExtensionPath}")
-//            }
-//        }
+        if (canBeCache) {
+            for (doc in res) {
+                // try to receive a post-include cached version
+                val docContentResult = postIncludeDocContentCache[doc.identifier]
+                if (docContentResult != null) {
+                    doc.modifyDocContentAndUpdate(docContentResult)
+                    println("loading post-include cached ${doc.fullyQualifiedPath}/${doc.fullyQualifiedExtensionPath}: $docContentResult")
+                }
+            }
+        }
 
-        return queryRes?.filter(queryFilter)
-    }
-
-    fun needsRebuild(): Boolean {
-        require(docToProcess != null) { "updatePreProcessing must be called before needsRebuild()" }
-        return needsRebuild(docToProcess!!)
+        return res
     }
 
     private fun needsRebuild(doc: DocumentableWrapper): Boolean {
         val context = context
         require(context != null) { "updatePreProcessing must be called before needsRebuild" }
 
-        fqNamesCache[doc.identifier] = Pair(doc.fullyQualifiedPath, doc.fullyQualifiedExtensionPath)
-
         // if source has changed, return true
         val sourceHasChanged = doc.getDocHashcode() != docContentSourceHashCodeCache[doc.identifier]
-        val doesNotContainVertex = !dependencyGraph.containsVertex(doc.identifier)
         val doesNotContainResultCache = docContentResultCache[doc.identifier] == null
+        val doesNotContainVertex = !dependencyGraph.containsVertex(doc.identifier)
 
-        if (doesNotContainVertex || doesNotContainResultCache || sourceHasChanged) {
+        if (doesNotContainVertex) dependencyGraph.addVertex(doc.identifier)
+
+        val dependencies = dependencyGraph.incomingEdgesOf(doc.identifier).map { it.from }
+
+        // else, check all dependencies for modifications
+        val dependencyDocs = dependencies.map { get(it) }
+
+        val dependenciesNeedsRebuild = dependencyDocs
+            .map { it == null || needsRebuild(it) } // mapping first to increase the documentableWrapperCache
+            .any { it }
+
+        val needsRebuild = sourceHasChanged ||
+                doesNotContainVertex ||
+                doesNotContainResultCache ||
+                dependenciesNeedsRebuild
+
+        if (needsRebuild) {
 
             // update the caches
             docContentSourceHashCodeCache[doc.identifier] = doc.getDocHashcode()
-            dependencyGraph.addVertex(doc.identifier)
+
             docContentResultCache.remove(doc.identifier)
-            return true
-        }
-        val dependencies = dependencyGraph.incomingEdgesOf(doc.identifier).map { it.from }
-        if (dependencies.isEmpty()) return false
+            postIncludeDocContentCache.remove(doc.identifier)
 
-        // else, check all dependencies for modifications
-        val dependencyDocs = dependencies.map {
-            val fqNames = fqNamesCache[it]
-            if (fqNames == null) {
-                null
-            } else {
-                val (fqName, fqExtName) = fqNames
-
-                // query for a new doc
-                buildList {
-                    queryNew(context, fqName)?.forEach { add(it) }
-                    if (fqExtName != null) {
-                        queryNew(context, fqExtName)?.forEach { add(it) }
-                    }
-                }.firstOrNull {
-                    it.identifier != doc.identifier
-                }
+            // and remove caches of docs dependent on this doc
+            BreadthFirstIterator(dependencyGraph, doc.identifier).forEach {
+                docContentResultCache.remove(it)
+                postIncludeDocContentCache.remove(it)
             }
         }
-
-        val needsRebuild = dependencyDocs
-            .map { it == null || needsRebuild(it) }
-            .any { it } // mapping first to increase the documentableWrapperCache
 
         return needsRebuild
     }
 
-    fun updatePostProcessing(resultDoc: DocumentableWrapper) {
-        // update dependency graph
-        val oldIncomingEdges = dependencyGraph.incomingEdgesOf(resultDoc.identifier)
-        val newIncomingEdges = resultDoc.dependsOn.map {
-            Edge(from = it.identifier, to = resultDoc.identifier)
-        }.toSet()
-
-        for (newEdge in (newIncomingEdges - oldIncomingEdges)) {
-            dependencyGraph.addVertex(newEdge.from)
-            dependencyGraph.addVertex(newEdge.to)
-            dependencyGraph.addEdge(newEdge.from, newEdge.to, newEdge)
-        }
-        for (removedEdge in (oldIncomingEdges - newIncomingEdges)) {
-            dependencyGraph.removeEdge(removedEdge)
-        }
-
-        // and caches
-        docContentResultCache[resultDoc.identifier] = resultDoc.docContent
-        fqNamesCache[resultDoc.identifier] = Pair(resultDoc.fullyQualifiedPath, resultDoc.fullyQualifiedExtensionPath)
-        resultDoc.dependsOn.forEach {
-            updatePostProcessing(it)
+    fun updatePostProcessing() {
+        for (doc in docsToProcess.values.flatten()) {
+            docContentResultCache[doc.identifier] = doc.docContent
         }
     }
 
@@ -166,7 +210,7 @@ open class DocumentablesByPathWithCache<C>(
         apply { this.queryFilter = queryFilter }
 
     override fun withDocsToProcessFilter(docsToProcessFilter: DocumentableWrapperFilter): MutableDocumentablesByPath =
-        apply { this.documentablesToProcessFilter = docsToProcessFilter}
+        apply { this.documentablesToProcessFilter = docsToProcessFilter }
 
     override fun withFilters(
         queryFilter: DocumentableWrapperFilter,

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/MutableDocumentableWrapper.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/MutableDocumentableWrapper.kt
@@ -22,6 +22,7 @@ open class MutableDocumentableWrapper(
     identifier: UUID,
     annotations: List<AnnotationWrapper>,
     fileTextRange: IntRange,
+    origin: Any,
 
     override var docContent: DocContent,
     override var tags: Set<String>,
@@ -46,6 +47,7 @@ open class MutableDocumentableWrapper(
     identifier = identifier,
     annotations = annotations,
     fileTextRange = fileTextRange,
+    origin = origin,
     htmlRangeStart = htmlRangeStart,
     htmlRangeEnd = htmlRangeEnd,
 ) {
@@ -82,6 +84,7 @@ fun DocumentableWrapper.toMutable(): MutableDocumentableWrapper =
         identifier = identifier,
         annotations = annotations,
         fileTextRange = fileTextRange,
+        origin = origin,
         htmlRangeStart = htmlRangeStart,
         htmlRangeEnd = htmlRangeEnd,
     )

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/MutableDocumentableWrapper.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/MutableDocumentableWrapper.kt
@@ -26,6 +26,7 @@ open class MutableDocumentableWrapper(
     override var docContent: DocContent,
     override var tags: Set<String>,
     override var isModified: Boolean,
+    override var dependsOn: List<DocumentableWrapper>,
 
     override var htmlRangeEnd: Int?,
     override var htmlRangeStart: Int?,
@@ -46,6 +47,7 @@ open class MutableDocumentableWrapper(
     identifier = identifier,
     annotations = annotations,
     fileTextRange = fileTextRange,
+    dependsOn = dependsOn,
     htmlRangeStart = htmlRangeStart,
     htmlRangeEnd = htmlRangeEnd,
 ) {
@@ -82,6 +84,7 @@ fun DocumentableWrapper.toMutable(): MutableDocumentableWrapper =
         identifier = identifier,
         annotations = annotations,
         fileTextRange = fileTextRange,
+        dependsOn = dependsOn,
         htmlRangeStart = htmlRangeStart,
         htmlRangeEnd = htmlRangeEnd,
     )

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/MutableDocumentableWrapper.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/MutableDocumentableWrapper.kt
@@ -26,7 +26,6 @@ open class MutableDocumentableWrapper(
     override var docContent: DocContent,
     override var tags: Set<String>,
     override var isModified: Boolean,
-    override var dependsOn: List<DocumentableWrapper>,
 
     override var htmlRangeEnd: Int?,
     override var htmlRangeStart: Int?,
@@ -47,7 +46,6 @@ open class MutableDocumentableWrapper(
     identifier = identifier,
     annotations = annotations,
     fileTextRange = fileTextRange,
-    dependsOn = dependsOn,
     htmlRangeStart = htmlRangeStart,
     htmlRangeEnd = htmlRangeEnd,
 ) {
@@ -84,7 +82,6 @@ fun DocumentableWrapper.toMutable(): MutableDocumentableWrapper =
         identifier = identifier,
         annotations = annotations,
         fileTextRange = fileTextRange,
-        dependsOn = dependsOn,
         htmlRangeStart = htmlRangeStart,
         htmlRangeEnd = htmlRangeEnd,
     )

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocAnalyser.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocAnalyser.kt
@@ -1,0 +1,55 @@
+package nl.jolanrensen.docProcessor
+
+/**
+ * Version of TagDocProcessor which does not modify any tags,
+ * but instead just allows you to visit all tags.
+ */
+abstract class TagDocAnalyser<out R> : TagDocProcessor() {
+
+    abstract fun analyseBlockTagWithContent(
+        tagWithContent: String,
+        path: String,
+        documentable: DocumentableWrapper,
+    )
+
+    abstract fun analyseInlineTagWithContent(
+        tagWithContent: String,
+        path: String,
+        documentable: DocumentableWrapper,
+    )
+
+    // Needs to call process!
+    abstract fun analyze(processLimit: Int, documentablesByPath: DocumentablesByPath): R
+
+    final override fun processBlockTagWithContent(
+        tagWithContent: String,
+        path: String,
+        documentable: DocumentableWrapper,
+    ): String {
+        analyseBlockTagWithContent(tagWithContent, path, documentable)
+        return tagWithContent
+    }
+
+    final override fun processInlineTagWithContent(
+        tagWithContent: String,
+        path: String,
+        documentable: DocumentableWrapper,
+    ): String {
+        analyseInlineTagWithContent(tagWithContent, path, documentable)
+        return tagWithContent
+    }
+
+    final override fun process(processLimit: Int, documentablesByPath: DocumentablesByPath): DocumentablesByPath =
+        super.process(processLimit, documentablesByPath)
+
+    // we only need one iteration for analyzing as no modifications can be made
+    final override fun shouldContinue(i: Int, anyModifications: Boolean, processLimit: Int): Boolean {
+        val processLimitReached = i >= processLimit
+
+        // Throw error if process limit is reached or if supported tags keep being present but no modifications are made
+        if (processLimitReached)
+            onProcessError()
+
+        return false
+    }
+}

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocAnalyser.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocAnalyser.kt
@@ -18,8 +18,12 @@ abstract class TagDocAnalyser<out R> : TagDocProcessor() {
         documentable: DocumentableWrapper,
     )
 
-    // Needs to call process!
-    abstract fun analyze(processLimit: Int, documentablesByPath: DocumentablesByPath): R
+    abstract fun getAnalyzedResult(): R
+
+    fun analyzeSafely(processLimit: Int, documentablesByPath: DocumentablesByPath): TagDocAnalyser<R> {
+        processSafely(processLimit, documentablesByPath)
+        return this
+    }
 
     final override fun processBlockTagWithContent(
         tagWithContent: String,
@@ -38,6 +42,11 @@ abstract class TagDocAnalyser<out R> : TagDocProcessor() {
         analyseInlineTagWithContent(tagWithContent, path, documentable)
         return tagWithContent
     }
+
+    protected final fun analyzeDocumentable(
+        documentable: DocumentableWrapper,
+        processLimit: Int,
+    ): Boolean = processDocumentable(documentable.toMutable(), processLimit)
 
     final override fun process(processLimit: Int, documentablesByPath: DocumentablesByPath): DocumentablesByPath =
         super.process(processLimit, documentablesByPath)

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocProcessor.kt
@@ -1,5 +1,9 @@
 package nl.jolanrensen.docProcessor
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+
 /**
  * Specific [DocProcessor] that processes just tags.
  *
@@ -48,6 +52,14 @@ abstract class TagDocProcessor : DocProcessor() {
     open fun <T : DocumentableWrapper> filterDocumentablesToProcess(documentable: T): Boolean = true
 
     open fun <T : DocumentableWrapper> filterDocumentablesToQuery(documentable: T): Boolean = true
+
+
+    /**
+     * Whether this processor can process multiple documentables in parallel.
+     * If `true`, the processor will be run in parallel for each documentable.
+     * If `false`, the processor will be run sequentially for each documentable.
+     */
+    open val canProcessParallel: Boolean = true
 
     /**
      * Provide a meaningful error message when the given process limit is reached.
@@ -149,26 +161,24 @@ abstract class TagDocProcessor : DocProcessor() {
         while (true) {
             val filteredDocumentablesWithTag = mutableDocumentablesByPath
                 .documentablesToProcess
-                .filter { it.value.any { it.hasSupportedTag } }
+                .flatMap { it.value }
+                .filter { it.hasSupportedTag }
+                .distinctBy { it.identifier }
 
             var anyModifications = false
-            for ((path, documentables) in filteredDocumentablesWithTag) {
-                for (documentable in documentables) {
+            if (canProcessParallel) {
+                runBlocking {
+                    anyModifications = filteredDocumentablesWithTag.mapNotNull { documentable ->
+                        if (!documentable.hasSupportedTag) null
+                        else async {
+                            processDocumentable(documentable, processLimit)
+                        }
+                    }.awaitAll().any { it }
+                }
+            } else {
+                for (documentable in filteredDocumentablesWithTag) {
                     if (!documentable.hasSupportedTag) continue
-
-                    val docContent = documentable.docContent
-                    val processedDoc = processTagsInContent(
-                        docContent = docContent,
-                        path = path,
-                        documentable = documentable,
-                        processLimit = processLimit,
-                    )
-
-                    val wasModified = docContent != processedDoc
-                    if (wasModified) {
-                        anyModifications = true
-                        documentable.modifyDocContentAndUpdate(processedDoc)
-                    }
+                    anyModifications = processDocumentable(documentable, processLimit)
                 }
             }
 
@@ -181,6 +191,25 @@ abstract class TagDocProcessor : DocProcessor() {
         }
 
         return mutableDocumentablesByPath
+    }
+
+    private fun processDocumentable(
+        documentable: MutableDocumentableWrapper,
+        processLimit: Int,
+    ): Boolean {
+        val docContent = documentable.docContent
+        val processedDoc = processTagsInContent(
+            docContent = docContent,
+            path = documentable.fullyQualifiedPath,
+            documentable = documentable,
+            processLimit = processLimit,
+        )
+
+        val wasModified = docContent != processedDoc
+        if (wasModified) {
+            documentable.modifyDocContentAndUpdate(processedDoc)
+        }
+        return wasModified
     }
 
     private fun processTagsInContent(
@@ -395,7 +424,7 @@ open class TagDocProcessorFailedException(
         appendLine(lineBreak)
         appendLine("### Tag throwing the exception:")
         appendLine()
-        appendLine("**`" + currentDoc.substring(rangeInCurrentDoc) + "`**")
+        appendLine("**`" + currentDoc.substring(rangeInCurrentDoc.coerceAtMost(currentDoc.lastIndex)) + "`**")
         appendLine(lineBreak)
         appendLine("### Reason for the exception:")
         appendLine()
@@ -414,7 +443,7 @@ open class TagDocProcessorFailedException(
             try {
                 currentDoc.replaceRange(
                     range = rangeInCurrentDoc,
-                    replacement = highlightException(currentDoc.substring(rangeInCurrentDoc)),
+                    replacement = highlightException(currentDoc.substring(rangeInCurrentDoc.coerceAtMost(currentDoc.lastIndex))),
                 )
             } catch (e: Throwable) {
                 currentDoc

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocProcessor.kt
@@ -32,7 +32,7 @@ abstract class TagDocProcessor : DocProcessor() {
         get() = tags.any(::tagIsSupported)
 
 
-    private lateinit var mutableDocumentablesByPath: MutableDocumentablesByPath
+    protected lateinit var mutableDocumentablesByPath: MutableDocumentablesByPath
 
     /**
      * Allows you to access the documentables to be processed as well as to gain
@@ -53,6 +53,15 @@ abstract class TagDocProcessor : DocProcessor() {
 
     open fun <T : DocumentableWrapper> filterDocumentablesToQuery(documentable: T): Boolean = true
 
+    /**
+     * You can optionally sort the documentables to optimize the order in which they are processed.
+     * [TagDocAnalyser] can be used for that.
+     */
+    open fun <T : DocumentableWrapper> sortDocumentables(
+        documentables: List<T>,
+        processLimit: Int,
+        documentablesByPath: DocumentablesByPath,
+    ): Iterable<T> = documentables
 
     /**
      * Whether this processor can process multiple documentables in parallel.
@@ -164,6 +173,7 @@ abstract class TagDocProcessor : DocProcessor() {
                 .flatMap { it.value }
                 .filter { it.hasSupportedTag }
                 .distinctBy { it.identifier }
+                .let { sortDocumentables(it, processLimit, documentablesByPath) }
 
             var anyModifications = false
             if (canProcessParallel) {

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/TagDocProcessor.kt
@@ -203,7 +203,7 @@ abstract class TagDocProcessor : DocProcessor() {
         return mutableDocumentablesByPath
     }
 
-    private fun processDocumentable(
+    protected fun processDocumentable(
         documentable: MutableDocumentableWrapper,
         processLimit: Int,
     ): Boolean {

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/dagUtils.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/dagUtils.kt
@@ -1,0 +1,8 @@
+package nl.jolanrensen.docProcessor
+
+import org.jgrapht.graph.DefaultEdge
+
+data class Edge<T : Any>(val from: T, val to: T) : DefaultEdge() {
+    override fun getSource(): Any = from
+    override fun getTarget(): Any = to
+}

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/ArgDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/ArgDocProcessor.kt
@@ -1,7 +1,7 @@
 package nl.jolanrensen.docProcessor.defaultProcessors
 
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import nl.jolanrensen.docProcessor.*
 import nl.jolanrensen.docProcessor.ProgrammingLanguage.JAVA
@@ -164,13 +164,13 @@ class ArgDocProcessor : TagDocProcessor() {
         runBlocking {
             mutable.documentablesToProcess.flatMap { (_, docs) ->
                 docs.map { doc ->
-                    async {
+                    launch {
                         doc.modifyDocContentAndUpdate(
                             doc.docContent.replaceDollarNotation()
                         )
                     }
                 }
-            }.awaitAll()
+            }.joinAll()
         }
 
         return super.process(processLimit, mutable)

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/ArgDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/ArgDocProcessor.kt
@@ -323,10 +323,7 @@ class ArgDocProcessor : TagDocProcessor() {
         )
 
         if (referencedDocumentable != null)
-            keys = listOfNotNull(
-                referencedDocumentable.fullyQualifiedPath,
-                referencedDocumentable.fullyQualifiedExtensionPath,
-            ).map { "[$it]" }
+            keys = referencedDocumentable.paths.map { "[$it]" }
 
         return keys
     }

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocAnalyzer.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocAnalyzer.kt
@@ -1,0 +1,99 @@
+package nl.jolanrensen.docProcessor.defaultProcessors
+
+import nl.jolanrensen.docProcessor.DocumentableWrapper
+import nl.jolanrensen.docProcessor.DocumentablesByPath
+import nl.jolanrensen.docProcessor.Edge
+import nl.jolanrensen.docProcessor.TagDocAnalyser
+import nl.jolanrensen.docProcessor.decodeCallableTarget
+import nl.jolanrensen.docProcessor.getTagArguments
+import nl.jolanrensen.docProcessor.withoutFilters
+import org.jgrapht.graph.SimpleDirectedGraph
+import java.util.*
+
+/**
+ * Generates a dependency graph of the [DocumentablesByPath] based on `@include tags`.
+ *
+ * Runtime Θ(n) where n is the number of documentables.
+ */
+internal class IncludeDocAnalyzer :
+    TagDocAnalyser<SimpleDirectedGraph<DocumentableWrapper, Edge<DocumentableWrapper>>>() {
+    companion object {
+        fun getAnalyzedResult(
+            processLimit: Int,
+            documentablesByPath: DocumentablesByPath,
+            analyzeQueriesToo: Boolean = false,
+        ): SimpleDirectedGraph<DocumentableWrapper, Edge<DocumentableWrapper>> =
+            IncludeDocAnalyzer()
+                .apply { this.analyzeQueriesToo = analyzeQueriesToo }
+                .analyzeSafely(processLimit, documentablesByPath)
+                .getAnalyzedResult()
+    }
+
+    override fun analyseBlockTagWithContent(
+        tagWithContent: String,
+        path: String,
+        documentable: DocumentableWrapper,
+    ) = analyseContent(tagWithContent, documentable)
+
+    override fun analyseInlineTagWithContent(
+        tagWithContent: String,
+        path: String,
+        documentable: DocumentableWrapper,
+    ) = analyseContent(tagWithContent, documentable)
+
+    private val unfilteredDocumentablesByPath by lazy { documentablesByPath.withoutFilters() }
+    private val dependencies: MutableSet<Edge<DocumentableWrapper>> = Collections.synchronizedSet(mutableSetOf())
+    internal var analyzeQueriesToo = false
+
+    private fun analyseContent(
+        line: String,
+        documentable: DocumentableWrapper,
+    ) {
+        val includeArguments = line.getTagArguments(tag = IncludeDocProcessor.TAG, numberOfArguments = 2)
+        val includePath = includeArguments.first().decodeCallableTarget()
+
+        // query the filtered documentables for the @include paths
+        val targetDocumentable = documentable.queryDocumentables(
+            query = includePath,
+            documentables = documentablesByPath,
+            documentablesNoFilters = unfilteredDocumentablesByPath,
+        ) { it.identifier != documentable.identifier }
+
+        if (targetDocumentable != null) {
+            // this depends on target, so add an edge from target to this, that makes sure the target goes first
+            dependencies += Edge(
+                from = targetDocumentable,
+                to = documentable,
+            )
+
+            if (analyzeQueriesToo) {
+                // todo check if already analyzed?
+                analyzeDocumentable(targetDocumentable, 10_000)
+            }
+        }
+    }
+
+    override fun getAnalyzedResult(): SimpleDirectedGraph<DocumentableWrapper, Edge<DocumentableWrapper>> {
+        require(hasRun) { "analyze must be called before getAnalyzedResult" }
+
+        val dag = SimpleDirectedGraph.createBuilder<DocumentableWrapper, _>(
+            Edge::class.java as Class<out Edge<DocumentableWrapper>>
+        )
+            .apply {
+                for (dep in dependencies) {
+                    addEdge(dep.from, dep.to, dep)
+                }
+            }
+            .build()
+
+        return dag
+    }
+
+    override fun tagIsSupported(tag: String): Boolean = tag == IncludeDocProcessor.TAG
+
+    override fun <T : DocumentableWrapper> filterDocumentablesToProcess(documentable: T): Boolean =
+        documentable.sourceHasDocumentation
+
+    override fun <T : DocumentableWrapper> filterDocumentablesToQuery(documentable: T): Boolean =
+        documentable.sourceHasDocumentation
+}

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocAnalyzer.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocAnalyzer.kt
@@ -44,6 +44,7 @@ internal class IncludeDocAnalyzer :
     private val unfilteredDocumentablesByPath by lazy { documentablesByPath.withoutFilters() }
     private val dependencies: MutableSet<Edge<DocumentableWrapper>> = Collections.synchronizedSet(mutableSetOf())
     internal var analyzeQueriesToo = false
+    private val analyzedDocumentables = mutableSetOf<UUID>()
 
     private fun analyseContent(
         line: String,
@@ -66,11 +67,11 @@ internal class IncludeDocAnalyzer :
                 to = documentable,
             )
 
-            if (analyzeQueriesToo) {
-                // todo check if already analyzed?
+            if (analyzeQueriesToo && targetDocumentable.identifier !in analyzedDocumentables) {
                 analyzeDocumentable(targetDocumentable, 10_000)
             }
         }
+        analyzedDocumentables += documentable.identifier
     }
 
     override fun getAnalyzedResult(): SimpleDirectedGraph<DocumentableWrapper, Edge<DocumentableWrapper>> {

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocProcessor.kt
@@ -139,8 +139,7 @@ class IncludeDocProcessor : TagDocProcessor() {
         // for stuff written after the @include tag, save and include it later
         val extraContent = includeArguments.getOrElse(1) { "" }
 
-        // TODO remove
-        println("Running include processor for ${documentable.fullyQualifiedPath}/${documentable.fullyQualifiedExtensionPath}, line @include $includePath")
+        logger.debug { "Running include processor for ${documentable.fullyQualifiedPath}/${documentable.fullyQualifiedExtensionPath}, line @include $includePath" }
 
         // query the filtered documentables for the @include paths
         val targetDocumentable = documentable.queryDocumentables(
@@ -211,7 +210,7 @@ class IncludeDocProcessor : TagDocProcessor() {
                             query = path,
                             documentables = unfilteredDocumentablesByPath,
                             documentablesNoFilters = unfilteredDocumentablesByPath,
-                        ) == it
+                        ) == it // TODO? not sure why identifier check gets the wrong results here
                     },
                 ) ?: query
             }

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocProcessor.kt
@@ -95,6 +95,11 @@ class IncludeDocProcessor : TagDocProcessor() {
         documentable.sourceHasDocumentation
 
     /**
+     * Documentables interact, so no parallel processing is possible.
+     */
+    override val canProcessParallel: Boolean = false
+
+    /**
      * Provides a helpful message when a circular reference is detected.
      */
     override fun onProcessError(): Nothing {

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/IncludeDocProcessor.kt
@@ -145,7 +145,7 @@ class IncludeDocProcessor : TagDocProcessor() {
             query = includePath,
             documentables = documentablesByPath,
             documentablesNoFilters = unfilteredDocumentablesByPath,
-        ) { it.identifier != documentable.identifier }// todo test
+        ) { it.identifier != documentable.identifier }
 
         if (targetDocumentable == null) {
             val targetDocumentableNoFilter = documentable.queryDocumentables(

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/RemoveEscapeCharsProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/RemoveEscapeCharsProcessor.kt
@@ -1,7 +1,7 @@
 package nl.jolanrensen.docProcessor.defaultProcessors
 
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import nl.jolanrensen.docProcessor.DocProcessor
 import nl.jolanrensen.docProcessor.DocumentablesByPath
@@ -29,13 +29,13 @@ class RemoveEscapeCharsProcessor : DocProcessor() {
         runBlocking {
             mutableDocs.documentablesToProcess.flatMap { (_, docs) ->
                 docs.map {
-                    async {
+                    launch {
                         it.modifyDocContentAndUpdate(
                             it.docContent.removeEscapeCharacters(escapeChars)
                         )
                     }
                 }
-            }.awaitAll()
+            }.joinAll()
         }
 
         return mutableDocs

--- a/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/SampleDocProcessor.kt
+++ b/doc-processor-common/src/main/kotlin/nl/jolanrensen/docProcessor/defaultProcessors/SampleDocProcessor.kt
@@ -70,7 +70,7 @@ class SampleDocProcessor : TagDocProcessor() {
 
         // query all documents for the sample path
         val targetDocumentable = queries.firstNotNullOfOrNull { query ->
-            documentablesByPath[query]?.firstOrNull()
+            documentablesByPath.query(query, documentable)?.firstOrNull()
         } ?: throwError(samplePath, queries)
 
         // get the source text of the target documentable, optionally trimming to between the

--- a/doc-processor-gradle-plugin/build.gradle.kts
+++ b/doc-processor-gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "nl.jolanrensen.docProcessor"
-version = "0.3.4-SNAPSHOT"
+version = "0.3.5-SNAPSHOT"
 
 publishing {
     repositories {

--- a/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
+++ b/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
@@ -11,7 +11,7 @@ import java.io.IOException
 
 abstract class DocProcessorFunctionalTest(name: String) {
 
-    protected val version = "0.3.4-SNAPSHOT"
+    protected val version = "0.3.5-SNAPSHOT"
 
     init {
         println("NOTE!! make sure you have the plugin installed in your local maven repo")

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
@@ -159,9 +159,7 @@ abstract class ProcessDocsAction {
 
         // collect the documentables with sources per path
         val documentablesPerPath: MutableMap<String, List<DocumentableWrapper>> = documentables
-            .flatMap { doc ->
-                listOfNotNull(doc.fullyQualifiedPath, doc.fullyQualifiedExtensionPath).map { it to doc }
-            }
+            .flatMap { doc -> doc.paths.map { it to doc } }
             .groupBy { it.first }
             .mapValues { it.value.map { it.second } }
             .toMutableMap()

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
@@ -14,6 +14,8 @@ import org.jetbrains.dokka.model.withDescendants
 import java.io.File
 import java.io.IOException
 import java.util.*
+import kotlin.time.DurationUnit
+import kotlin.time.measureTimedValue
 
 private val log = KotlinLogging.logger {}
 
@@ -47,7 +49,11 @@ abstract class ProcessDocsAction {
 
     protected fun process() {
         // analyse the sources with dokka to get the documentables
-        val sourceDocs = analyseSourcesWithDokka()
+        log.lifecycle { "Analyzing sources..." }
+        val (sourceDocs, time) = measureTimedValue {
+            analyseSourcesWithDokka()
+        }
+        log.lifecycle { "  - Finished in ${time.toString(DurationUnit.SECONDS)}." }
 
         // Find all processors
         val processors = findProcessors(parameters.processors, parameters.arguments)
@@ -60,8 +66,12 @@ abstract class ProcessDocsAction {
         // Run all processors
         val modifiedDocumentables =
             processors.fold(sourceDocs) { acc, processor ->
-                log.lifecycle { "Running processor: ${processor::class.qualifiedName}" }
-                processor.processSafely(processLimit = parameters.processLimit, documentablesByPath = acc)
+                log.lifecycle { "Running processor: ${processor::class.qualifiedName}..." }
+                val (docs, time) = measureTimedValue {
+                    processor.processSafely(processLimit = parameters.processLimit, documentablesByPath = acc)
+                }
+                log.lifecycle { "  - Finished in ${time.toString(DurationUnit.SECONDS)}." }
+                docs
             }.documentablesToProcess
 
         // filter to only include the modified documentables

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperDokka.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperDokka.kt
@@ -117,5 +117,6 @@ fun DocumentableWrapper.Companion.createFromDokkaOrNull(
         docIndent = docIndent,
         annotations = annotations,
         fileTextRange = fileTextRange,
+        dependsOn = emptyList(),
     )
 }

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperDokka.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperDokka.kt
@@ -31,8 +31,7 @@ fun DocumentableWrapper.Companion.createFromDokkaOrNull(
         logger = logger,
     )
 
-    val path = documentable.dri.fullyQualifiedPath
-    val extensionPath = documentable.dri.fullyQualifiedExtensionPath
+    val paths = documentable.dri.paths
     val file = File(source.path)
 
     if (!file.exists()) {
@@ -53,14 +52,14 @@ fun DocumentableWrapper.Companion.createFromDokkaOrNull(
         require(startComment != -1) {
             """
                     |Could not find start of comment.
-                    |Paths: ${listOfNotNull(path, extensionPath)}
+                    |Paths: $paths
                     |Comment Content: "${docComment.documentString}"
                     |Query: "$query"""".trimMargin()
         }
         require(endComment != -1) {
             """
                     |Could not find end of comment.
-                    |Paths: ${listOfNotNull(path, extensionPath)}
+                    |Paths: $paths
                     |Comment Content: "${docComment.documentString}"
                     |Query: "$query"""".trimMargin()
         }
@@ -93,9 +92,7 @@ fun DocumentableWrapper.Companion.createFromDokkaOrNull(
     val superPaths = (documentable as? WithSupertypes)
         ?.supertypes
         ?.flatMap { it.value }
-        ?.flatMap {
-            it.typeConstructor.dri.let { listOfNotNull(it.fullyQualifiedPath, it.fullyQualifiedExtensionPath) }
-        }
+        ?.flatMap { it.typeConstructor.dri.paths }
         ?: emptyList()
 
     val annotations = documentable.annotations().values.flatten().map {
@@ -109,14 +106,16 @@ fun DocumentableWrapper.Companion.createFromDokkaOrNull(
         programmingLanguage = source.programmingLanguage,
         imports = imports,
         rawSource = rawSource,
-        fullyQualifiedPath = path,
-        fullyQualifiedExtensionPath = extensionPath,
+        fullyQualifiedPath = paths[0],
+        fullyQualifiedExtensionPath = paths.getOrNull(1),
         fullyQualifiedSuperPaths = superPaths,
         file = file,
         docFileTextRange = docFileTextRange.toIntRange(),
         docIndent = docIndent,
         annotations = annotations,
         fileTextRange = fileTextRange,
-        dependsOn = emptyList(),
+        origin = documentable,
     )
 }
+
+fun DocumentableWrapper.getOrigin(): Documentable = origin as Documentable

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/dokkaUtils.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/dokkaUtils.kt
@@ -317,6 +317,9 @@ val DRI.fullyQualifiedExtensionPath: String?
         ).flatten().joinToString(".")
     }
 
+val DRI.paths: List<String>
+    get() = listOfNotNull(fullyQualifiedPath, fullyQualifiedExtensionPath)
+
 val TypeReference.path: String
     get() = when (this) {
         is TypeConstructor -> fullyQualifiedName

--- a/doc-processor-intellij-plugin/build.gradle.kts
+++ b/doc-processor-intellij-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "nl.jolanrensen.docProcessor"
-version = "0.3.4-SNAPSHOT"
+version = "0.3.5-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperIntellij.kt
+++ b/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperIntellij.kt
@@ -111,6 +111,5 @@ fun DocumentableWrapper.Companion.createFromIntellijOrNull(
         docIndent = docIndent,
         annotations = annotations,
         fileTextRange = fileTextRange,
-        dependsOn = emptyList(),
     )
 }

--- a/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperIntellij.kt
+++ b/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperIntellij.kt
@@ -32,6 +32,7 @@ fun DocumentableWrapper.Companion.createFromIntellijOrNull(
             ?.asString()
             ?.let { "$it.${documentable.name}" }
     } else null
+    val paths = listOfNotNull(path, extensionPath)
 
     val file = File(documentable.containingFile.originalFile.virtualFile.path)
 
@@ -53,14 +54,14 @@ fun DocumentableWrapper.Companion.createFromIntellijOrNull(
         require(startComment != -1) {
             """
                     |Could not find start of comment.
-                    |Paths: ${listOfNotNull(path, extensionPath)}
+                    |Paths: $paths
                     |Comment Content: "${docComment.text.getDocContentOrNull()}"
                     |Query: "$query"""".trimMargin()
         }
         require(endComment != -1) {
             """
                     |Could not find end of comment.
-                    |Paths: ${listOfNotNull(path, extensionPath)}
+                    |Paths: $paths
                     |Comment Content: "${docComment.text.getDocContentOrNull()}"
                     |Query: "$query"""".trimMargin()
         }
@@ -111,5 +112,8 @@ fun DocumentableWrapper.Companion.createFromIntellijOrNull(
         docIndent = docIndent,
         annotations = annotations,
         fileTextRange = fileTextRange,
+        origin = documentable,
     )
 }
+
+fun DocumentableWrapper.getOrigin(): PsiElement = origin as PsiElement

--- a/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperIntellij.kt
+++ b/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/documentableWrapperIntellij.kt
@@ -111,5 +111,6 @@ fun DocumentableWrapper.Companion.createFromIntellijOrNull(
         docIndent = docIndent,
         annotations = annotations,
         fileTextRange = fileTextRange,
+        dependsOn = emptyList(),
     )
 }

--- a/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/services/PostIncludeDocProcessorCacheCollector.kt
+++ b/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/services/PostIncludeDocProcessorCacheCollector.kt
@@ -1,0 +1,21 @@
+package nl.jolanrensen.docProcessor.services
+
+import com.intellij.psi.PsiElement
+import nl.jolanrensen.docProcessor.DocAnalyser
+import nl.jolanrensen.docProcessor.DocumentablesByPath
+import nl.jolanrensen.docProcessor.DocumentablesByPathWithCache
+
+class PostIncludeDocProcessorCacheCollector(
+    private val cacheHolder: DocumentablesByPathWithCache<PsiElement>,
+) : DocAnalyser<Unit>() {
+
+    override fun getAnalyzedResult() = Unit
+
+    override fun analyze(processLimit: Int, documentablesByPath: DocumentablesByPath) {
+        documentablesByPath.documentablesToProcess.values.forEach {
+            it.forEach { documentable ->
+                cacheHolder.updatePostIncludeDocContentResult(documentable)
+            }
+        }
+    }
+}

--- a/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/services/PostIncludeDocProcessorCacheCollector.kt
+++ b/doc-processor-intellij-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/services/PostIncludeDocProcessorCacheCollector.kt
@@ -1,12 +1,11 @@
 package nl.jolanrensen.docProcessor.services
 
-import com.intellij.psi.PsiElement
 import nl.jolanrensen.docProcessor.DocAnalyser
 import nl.jolanrensen.docProcessor.DocumentablesByPath
 import nl.jolanrensen.docProcessor.DocumentablesByPathWithCache
 
 class PostIncludeDocProcessorCacheCollector(
-    private val cacheHolder: DocumentablesByPathWithCache<PsiElement>,
+    private val cacheHolder: DocumentablesByPathWithCache,
 ) : DocAnalyser<Unit>() {
 
     override fun getAnalyzedResult() = Unit


### PR DESCRIPTION
This achieves a couple goals with regards to https://github.com/Jolanrensen/docProcessorGradlePlugin/issues/40

- Doc processors can now run in parallel (enabled by default in TagDocProcessor with `canProcessParallel`). This is disabled for `@include` to prevent concurrent modifications.
- Include can now pre-sort docs (can be disabled by setting the argument `INCLUDE_DOC_PROCESSOR_PRE_SORT` to false) before running. This analyses the docs in O(n), creates a dependency graph which then outputs an order in such a way that each doc can be rendered in one go, O(n) again. This is different from before where some parts of text could be processed multiple times. In practice or with smaller code bases, the performance could be worse with pre-sorting (as all docs now have to be analysed twice), but in larger code bases you might notice a difference.
- Generating a dependency graph is done by `IncludeDocAnalyzer`, a `TagDocAnalyser` which is the same as a `TagDocProcessor` but without changing the docs.
- Added speed indicators to the lifecycle of the gradle plugin.
- The most interesting part now is the IntelliJ plugin. I wanted to have support for the "rendered docs" feature of IntelliJ which could display, well, rendered docs right next to the code. However, since the plugin works one doc at a time, this very quickly became very slow. So, I changed `DocumentablesByPathWithCache` to an advanced caching system, taking track of changes in a doc + doc `@include` dependencies with a dependency graph again. I cache both the doc content results (the final rendered doc), as well as a post-include state. This post-include state cache is to prevent deep `@include` paths with many queries and just overall less work, similar to pre-sort for the gradle plugin.
The result is a way faster experience, especially when you're not modifying code (it can just load the cache) and, when "Render all doc comments" is enabled, you can modify one doc and see (relatively) live results in docs dependent on it! 