### PR TITLE
Updating Dokka to 2.0.0(-Beta)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,7 @@ ktlint_ignore_back_ticked_identifier = true
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
 ktlint_standard_chain-method-continuation = disabled
+ktlint_standard_when-entry-bracing = disabled
 
 [{*/build/**/*}]
 ktlint = disabled

--- a/README.md
+++ b/README.md
@@ -517,8 +517,7 @@ Currently, the only way to try this is by building the plugin yourself from sour
 The plugin in its current state is unconfigurable and just uses the default processors as shown in the sample above.
 Also, it uses the IDE engine to resolve references.
 This is because it's a lot faster than my own engine + Dokka, but it does mean that there might be some differences
-with the preview and how it will look in the final docs (for instance, type aliases work in the IDE but not in the
-Gradle plugin). So, take this into account.
+with the preview and how it will look in the final docs. So, take this into account.
 
 I'm still working on connecting it to the Gradle plugin somehow or provide a way to configure it correctly,
 but until then, you can use it as is and be more efficient in your documentation writing!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.0.10" apply false
+    kotlin("jvm") version "2.0.20" apply false
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 }

--- a/doc-processor-gradle-plugin/build.gradle.kts
+++ b/doc-processor-gradle-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -38,15 +39,15 @@ dependencies {
     shadow(gradleKotlinDsl())
 
     // Dokka dependencies
-    val dokkaVersion = "1.8.10"
-    shadow("org.jetbrains.dokka:dokka-analysis:$dokkaVersion")
+    val dokkaVersion = "2.0.0-Beta"
+    shadow("org.jetbrains.dokka:analysis-kotlin-symbols:$dokkaVersion")
     shadow("org.jetbrains.dokka:dokka-base:$dokkaVersion")
     shadow("org.jetbrains.dokka:dokka-core:$dokkaVersion")
     shadow("org.jetbrains.dokka:dokka-base-test-utils:$dokkaVersion")
     shadow("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
 
     // logging
-    api("io.github.microutils:kotlin-logging:3.0.5")
+    api("io.github.oshai:kotlin-logging:7.0.0")
 
     // Use JUnit test framework for unit tests
     testImplementation(kotlin("test"))
@@ -111,7 +112,7 @@ tasks.check {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "11"
+    compilerOptions.jvmTarget = JvmTarget.JVM_11
 }
 
 java {

--- a/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DataFrameTest.kt
+++ b/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DataFrameTest.kt
@@ -1,9 +1,9 @@
 package nl.jolanrensen.docProcessor
 
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.Ignore
 import org.junit.Test
 import java.io.File
-import kotlin.test.Ignore
 
 class DataFrameTest : DocProcessorFunctionalTest("df") {
 
@@ -24,8 +24,8 @@ class DataFrameTest : DocProcessorFunctionalTest("df") {
         tomlFile.write(txt)
     }
 
-    @Test
     @Ignore
+    @Test
     fun `build DataFrame`() {
         GradleRunner.create()
             .forwardOutput()

--- a/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
+++ b/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
@@ -120,7 +120,7 @@ abstract class DocProcessorFunctionalTest(name: String) {
         tasks.compileKotlin { dependsOn(processKdocMain) }
         
         tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-            kotlinOptions.jvmTarget = "1.8"
+            compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
         }
         java {
             toolchain {

--- a/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
+++ b/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
@@ -81,7 +81,7 @@ abstract class DocProcessorFunctionalTest(name: String) {
         import nl.jolanrensen.docProcessor.defaultProcessors.*
         
         plugins {  
-            kotlin("jvm") version "1.9.21"
+            kotlin("jvm") version "2.0.20"
             id("nl.jolanrensen.docProcessor") version "$version"
         }
         

--- a/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
+++ b/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/DocProcessorFunctionalTest.kt
@@ -63,8 +63,15 @@ abstract class DocProcessorFunctionalTest(name: String) {
         annotation class ${ExcludeFromSources::class.simpleName}
     """.trimIndent()
 
+    @Language("properties")
+    private val propertiesFile =
+        """
+        org.gradle.jvmargs=-Xmx6g
+        """.trimIndent()
+
     @Language("kts")
-    private val settingsFile = """
+    private val settingsFile =
+        """
         pluginManagement {
             repositories {
                 mavenLocal()
@@ -72,7 +79,7 @@ abstract class DocProcessorFunctionalTest(name: String) {
                 mavenCentral()
             }
         }
-    """.trimIndent()
+        """.trimIndent()
 
     @Language("kts")
     private fun getBuildFileContent(processors: List<String>, plugins: List<String>): String =
@@ -194,6 +201,9 @@ abstract class DocProcessorFunctionalTest(name: String) {
 
         File(projectDirectory, "settings.gradle.kts")
             .write(settingsFile)
+
+        File(projectDirectory, "gradle.properties")
+            .write(propertiesFile)
 
         File(projectDirectory, "build.gradle.kts")
             .write(getBuildFileContent(processors, plugins))

--- a/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/TestInclude.kt
+++ b/doc-processor-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/docProcessor/TestInclude.kt
@@ -1010,4 +1010,74 @@ class TestInclude : DocProcessorFunctionalTest(name = "include") {
             processors = processors,
         ) shouldBe expectedOutput
     }
+
+    @Test
+    fun `type alias reading`() {
+        @Language("kt")
+        val content = """
+            /**
+             * Hello World!
+             */
+            typealias HelloWorld = String
+            
+            /**
+             * @include [HelloWorld]
+             */
+            fun helloWorld2() {}
+        """.trimIndent()
+
+        @Language("kt")
+        val expectedOutput = """
+            /**
+             * Hello World!
+             */
+            typealias HelloWorld = String
+            
+            /**
+             * Hello World!
+             */
+            fun helloWorld2() {}
+        """.trimIndent()
+
+        processContent(
+            content = content,
+            packageName = "",
+            processors = processors,
+        ) shouldBe expectedOutput
+    }
+
+    @Test
+    fun `type alias writing`() {
+        @Language("kt")
+        val content = """
+            /**
+             * Hello World!
+             */
+            fun helloWorld() {}
+            
+            /**
+             * @include [helloWorld]
+             */
+            typealias HelloWorld2 = String
+        """.trimIndent()
+
+        @Language("kt")
+        val expectedOutput = """
+            /**
+             * Hello World!
+             */
+            fun helloWorld() {}
+            
+            /**
+             * Hello World!
+             */
+            typealias HelloWorld2 = String
+        """.trimIndent()
+
+        processContent(
+            content = content,
+            packageName = "",
+            processors = processors,
+        ) shouldBe expectedOutput
+    }
 }

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapperDokka.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapperDokka.kt
@@ -1,6 +1,8 @@
 package nl.jolanrensen.docProcessor
 
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiNamedElement
+import org.jetbrains.dokka.InternalDokkaApi
 import org.jetbrains.dokka.base.signatures.KotlinSignatureUtils.annotations
 import org.jetbrains.dokka.model.AnnotationValue
 import org.jetbrains.dokka.model.Documentable
@@ -21,13 +23,14 @@ import java.io.File
  *   This represents the source of the [documentable] pointing to a language-specific AST/PSI.
  * @param [logger] [Dokka logger][DokkaLogger] that's needed for [findClosestDocComment]. Should be given.
  */
+@OptIn(InternalDokkaApi::class)
 fun DocumentableWrapper.Companion.createFromDokkaOrNull(
     documentable: Documentable,
     source: DocumentableSource,
     logger: DokkaLogger,
 ): DocumentableWrapper? {
     val docComment = findClosestDocComment(
-        element = source.psi,
+        element = source.psi as PsiNamedElement,
         logger = logger,
     )
 

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapperDokka.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/DocumentableWrapperDokka.kt
@@ -30,7 +30,7 @@ fun DocumentableWrapper.Companion.createFromDokkaOrNull(
     logger: DokkaLogger,
 ): DocumentableWrapper? {
     val docComment = findClosestDocComment(
-        element = source.psi as PsiNamedElement,
+        element = source.psi as PsiNamedElement?,
         logger = logger,
     )
 

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/DokkaUtils.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/DokkaUtils.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalDokkaApi::class)
+
 package nl.jolanrensen.docProcessor
 
 /*
@@ -14,54 +16,57 @@ import com.intellij.psi.PsiDocCommentOwner
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaCodeReferenceElement
 import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.PsiQualifiedNamedElement
 import com.intellij.psi.impl.source.tree.JavaDocElementType
 import com.intellij.psi.javadoc.PsiDocComment
 import com.intellij.psi.javadoc.PsiDocTag
 import com.intellij.psi.util.PsiTreeUtil
-import org.jetbrains.dokka.analysis.DescriptorDocumentableSource
-import org.jetbrains.dokka.analysis.PsiDocumentableSource
-import org.jetbrains.dokka.analysis.from
+import org.jetbrains.dokka.InternalDokkaApi
+import org.jetbrains.dokka.analysis.java.DescriptionJavadocTag
+import org.jetbrains.dokka.analysis.java.ExceptionJavadocTag
+import org.jetbrains.dokka.analysis.java.JavadocTag
+import org.jetbrains.dokka.analysis.java.ParamJavadocTag
+import org.jetbrains.dokka.analysis.java.ThrowingExceptionJavadocTag
+import org.jetbrains.dokka.analysis.java.ThrowsJavadocTag
+import org.jetbrains.dokka.analysis.java.doccomment.DocComment
+import org.jetbrains.dokka.analysis.java.doccomment.DocCommentCreator
+import org.jetbrains.dokka.analysis.java.doccomment.DocumentationContent
+import org.jetbrains.dokka.analysis.java.util.PsiDocumentableSource
+import org.jetbrains.dokka.analysis.java.util.from
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.links.JavaClassReference
 import org.jetbrains.dokka.links.Nullable
 import org.jetbrains.dokka.links.TypeConstructor
 import org.jetbrains.dokka.links.TypeReference
-import org.jetbrains.dokka.model.AnnotationParameterValue
-import org.jetbrains.dokka.model.AnnotationValue
-import org.jetbrains.dokka.model.ArrayValue
-import org.jetbrains.dokka.model.BooleanValue
-import org.jetbrains.dokka.model.Callable
-import org.jetbrains.dokka.model.ClassValue
-import org.jetbrains.dokka.model.DClasslike
-import org.jetbrains.dokka.model.DParameter
-import org.jetbrains.dokka.model.DTypeAlias
-import org.jetbrains.dokka.model.Documentable
-import org.jetbrains.dokka.model.DocumentableSource
-import org.jetbrains.dokka.model.DoubleValue
-import org.jetbrains.dokka.model.EnumValue
-import org.jetbrains.dokka.model.FloatValue
-import org.jetbrains.dokka.model.IntValue
-import org.jetbrains.dokka.model.LiteralValue
-import org.jetbrains.dokka.model.LongValue
-import org.jetbrains.dokka.model.NullValue
-import org.jetbrains.dokka.model.StringValue
+import org.jetbrains.dokka.model.*
 import org.jetbrains.dokka.utilities.DokkaLogger
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.idea.base.utils.fqname.getKotlinFqName
-import org.jetbrains.kotlin.idea.kdoc.findKDoc
-import org.jetbrains.kotlin.idea.search.usagesSearch.descriptor
-import org.jetbrains.kotlin.idea.util.hasComments
-import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.kdoc.parser.KDocKnownTag
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
+import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
+import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 import org.jetbrains.kotlin.renderer.render
-import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 import org.jetbrains.kotlin.resolve.ImportPath
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
+import org.jetbrains.kotlin.utils.addToStdlib.UnsafeCastFunction
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
@@ -77,16 +82,6 @@ fun Documentable.isLinkableElement(): Boolean =
         this is DParameter ||
         this is DTypeAlias // TODO: issue #12: will not be included in DocumentableWithSources since it has no source
 
-sealed interface DocComment {
-    fun hasTag(tag: JavadocTag): Boolean
-
-    fun hasTagWithExceptionOfType(tag: JavadocTag, exceptionFqName: String): Boolean
-
-    fun tagsByName(tag: JavadocTag, param: String? = null): List<DocumentationContent>
-
-    val tagNames: List<String>
-}
-
 /**
  * Get Kdoc content. Note! This doesn't include the @ Kdoc tags.
  *
@@ -97,7 +92,8 @@ val DocComment.documentString: String?
     get() = when (this) {
         is JavaDocComment -> comment.text
         is KotlinDocComment -> comment.text
-    }.getDocContentOrNull()
+        else -> null
+    }?.getDocContentOrNull()
 
 /**
  * Get text range of Kdoc/JavaDoc comment from /** to */
@@ -109,15 +105,20 @@ val DocComment.textRange: TextRange
     get() = when (this) {
         is JavaDocComment -> comment.textRange
         is KotlinDocComment -> comment.parent.textRange
+        else -> error("")
     }
 
 /**
  * Gets the [PsiNamedElement] from the [DocumentableSource] if it can find it.
  */
-val DocumentableSource.psi: PsiNamedElement?
-    get() = when (this) {
-        is PsiDocumentableSource -> psi
-        is DescriptorDocumentableSource -> descriptor.findPsi() as PsiNamedElement?
+val DocumentableSource.psi: PsiElement?
+    get() = when (this::class.qualifiedName) {
+        PsiDocumentableSource::class.qualifiedName -> (this as PsiDocumentableSource).psi
+        "org.jetbrains.dokka.analysis.kotlin.symbols.services.KtPsiDocumentableSource" ->
+            Class.forName("org.jetbrains.dokka.analysis.kotlin.symbols.services.KtPsiDocumentableSource")
+                .getMethod("getPsi")
+                .invoke(this) as PsiElement?
+
         else -> null
     }
 
@@ -127,111 +128,220 @@ val DocumentableSource.psi: PsiNamedElement?
 val DocumentableSource.textRange: TextRange?
     get() = psi?.textRange
 
-data class JavaDocComment(val comment: PsiDocComment) : DocComment {
-    override fun hasTag(tag: JavadocTag): Boolean = comment.hasTag(tag)
+internal class JavaDocComment(val comment: PsiDocComment) : DocComment {
+    override fun hasTag(tag: JavadocTag): Boolean {
+        return when (tag) {
+            is ThrowingExceptionJavadocTag -> hasTag(tag)
+            else -> comment.hasTag(tag)
+        }
+    }
 
-    override fun hasTagWithExceptionOfType(tag: JavadocTag, exceptionFqName: String): Boolean =
-        comment.hasTag(tag) &&
-            comment
-                .tagsByName(tag)
-                .firstIsInstanceOrNull<PsiDocTag>()
-                ?.resolveToElement()
-                ?.getKotlinFqName()
-                ?.asString() == exceptionFqName
+    private fun hasTag(tag: ThrowingExceptionJavadocTag): Boolean =
+        comment.hasTag(tag) && comment.resolveTag(tag).firstIsInstanceOrNull<PsiDocTag>()
+            ?.resolveToElement()
+            ?.getKotlinFqName() == tag.exceptionQualifiedName
 
-    override fun tagsByName(tag: JavadocTag, param: String?): List<DocumentationContent> =
-        comment.tagsByName(tag).map { PsiDocumentationContent(it, tag) }
+    override fun resolveTag(tag: JavadocTag): List<DocumentationContent> {
+        return when (tag) {
+            is ParamJavadocTag -> resolveParamTag(tag)
+            is ThrowingExceptionJavadocTag -> resolveThrowingTag(tag)
+            else -> comment.resolveTag(tag).map { PsiDocumentationContent(it, tag) }
+        }
+    }
 
-    override val tagNames: List<String>
-        get() = comment.tags.map { it.name }
+    private fun resolveParamTag(tag: ParamJavadocTag): List<DocumentationContent> {
+        val resolvedParamElements = comment.resolveTag(tag)
+            .filterIsInstance<PsiDocTag>()
+            .map { it.contentElementsWithSiblingIfNeeded() }
+            .firstOrNull { it.firstOrNull()?.text == tag.paramName }.orEmpty()
+
+        return resolvedParamElements
+            .withoutReferenceLink()
+            .map { PsiDocumentationContent(it, tag) }
+    }
+
+    private fun resolveThrowingTag(tag: ThrowingExceptionJavadocTag): List<DocumentationContent> {
+        val resolvedElements = comment.resolveTag(tag)
+            .flatMap {
+                when (it) {
+                    is PsiDocTag -> it.contentElementsWithSiblingIfNeeded()
+                    else -> listOf(it)
+                }
+            }
+
+        return resolvedElements
+            .withoutReferenceLink()
+            .map { PsiDocumentationContent(it, tag) }
+    }
+
+    private fun PsiDocComment.resolveTag(tag: JavadocTag): List<PsiElement> {
+        return when (tag) {
+            DescriptionJavadocTag -> this.descriptionElements.toList()
+            else -> this.findTagsByName(tag.name).toList()
+        }
+    }
+
+    private fun List<PsiElement>.withoutReferenceLink(): List<PsiElement> = drop(1)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JavaDocComment
+
+        if (comment != other.comment) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return comment.hashCode()
+    }
 }
 
-data class KotlinDocComment(val comment: KDocTag, val descriptor: DeclarationDescriptor?) : DocComment {
-
-    override fun hasTag(tag: JavadocTag): Boolean =
-        when (tag) {
-            JavadocTag.DESCRIPTION -> comment.getContent().isNotEmpty()
-            else -> tagsWithContent.any { it.text.startsWith("@$tag") }
-        }
-
-    override fun hasTagWithExceptionOfType(tag: JavadocTag, exceptionFqName: String): Boolean =
-        tagsWithContent.any { it.hasExceptionWithName(tag, exceptionFqName) }
-
-    override fun tagsByName(tag: JavadocTag, param: String?): List<DocumentationContent> =
-        when (tag) {
-            JavadocTag.DESCRIPTION -> listOf(DescriptorDocumentationContent(descriptor, comment, tag))
-
-            else ->
-                comment.children
-                    .mapNotNull { (it as? KDocTag) }
-                    .filter { it.name == "$tag" && param?.let { param -> it.hasExceptionWithName(param) } != false }
-                    .map { DescriptorDocumentationContent(descriptor, it, tag) }
-        }
-
-    override val tagNames: List<String>
-        get() = tagsWithContent.mapNotNull { it.name }
+class KotlinDocComment(
+    val comment: KDocTag,
+    val resolveDocContext: ResolveDocContext
+) : DocComment {
 
     private val tagsWithContent: List<KDocTag> = comment.children.mapNotNull { (it as? KDocTag) }
 
-    private fun KDocTag.hasExceptionWithName(tag: JavadocTag, exceptionFqName: String) =
-        text.startsWith("@$tag") && hasExceptionWithName(exceptionFqName)
+    override fun hasTag(tag: JavadocTag): Boolean {
+        return when (tag) {
+            is DescriptionJavadocTag -> comment.getContent().isNotEmpty()
+            is ThrowingExceptionJavadocTag -> tagsWithContent.any { it.hasException(tag) }
+            else -> tagsWithContent.any { it.text.startsWith("@${tag.name}") }
+        }
+    }
 
-    private fun KDocTag.hasExceptionWithName(exceptionFqName: String) = getSubjectName() == exceptionFqName
+    private fun KDocTag.hasException(tag: ThrowingExceptionJavadocTag) =
+        text.startsWith("@${tag.name}") && getSubjectName() == tag.exceptionQualifiedName
+
+    override fun resolveTag(tag: JavadocTag): List<DocumentationContent> {
+        return when (tag) {
+            is DescriptionJavadocTag -> listOf(DescriptorDocumentationContent(resolveDocContext, comment, tag))
+            is ParamJavadocTag -> {
+                val resolvedContent = resolveGeneric(tag)
+                listOf(resolvedContent[tag.paramIndex])
+            }
+
+            is ThrowsJavadocTag -> resolveThrowingException(tag)
+            is ExceptionJavadocTag -> resolveThrowingException(tag)
+            else -> resolveGeneric(tag)
+        }
+    }
+
+    private fun resolveThrowingException(tag: ThrowingExceptionJavadocTag): List<DescriptorDocumentationContent> {
+        val exceptionName = tag.exceptionQualifiedName ?: return resolveGeneric(tag)
+
+        return comment.children
+            .filterIsInstance<KDocTag>()
+            .filter { it.name == tag.name && it.getSubjectName() == exceptionName }
+            .map { DescriptorDocumentationContent(resolveDocContext, it, tag) }
+    }
+
+    private fun resolveGeneric(tag: JavadocTag): List<DescriptorDocumentationContent> {
+        return comment.children.mapNotNull { element ->
+            if (element is KDocTag && element.name == tag.name) {
+                DescriptorDocumentationContent(resolveDocContext, element, tag)
+            } else {
+                null
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as KotlinDocComment
+
+        if (comment != other.comment) return false
+        //if (resolveDocContext.name != other.resolveDocContext.name) return false
+        if (tagsWithContent != other.tagsWithContent) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = comment.hashCode()
+        // result = 31 * result + resolveDocContext.name.hashCode()
+        result = 31 * result + tagsWithContent.hashCode()
+        return result
+    }
 }
 
 interface DocumentationContent {
     val tag: JavadocTag
 }
 
-data class PsiDocumentationContent(val psiElement: PsiElement, override val tag: JavadocTag) : DocumentationContent
+data class PsiDocumentationContent(
+    val psiElement: PsiElement,
+    override val tag: JavadocTag
+) : DocumentationContent {
+
+    override fun resolveSiblings(): List<DocumentationContent> {
+        return if (psiElement is PsiDocTag) {
+            psiElement.contentElementsWithSiblingIfNeeded()
+                .map { content -> PsiDocumentationContent(content, tag) }
+        } else {
+            listOf(this)
+        }
+    }
+}
+
+fun PsiDocTag.contentElementsWithSiblingIfNeeded(): List<PsiElement> = if (dataElements.isNotEmpty()) {
+    listOfNotNull(
+        dataElements[0],
+        dataElements[0].nextSibling?.takeIf { it.text != dataElements.drop(1).firstOrNull()?.text },
+        *dataElements.drop(1).toTypedArray()
+    )
+} else {
+    emptyList()
+}
+
+class ResolveDocContext(val ktElement: KtElement)
 
 data class DescriptorDocumentationContent(
-    val descriptor: DeclarationDescriptor?,
+    val resolveDocContext: ResolveDocContext,
     val element: KDocTag,
     override val tag: JavadocTag,
-) : DocumentationContent
+) : DocumentationContent {
+    override fun resolveSiblings(): List<DocumentationContent> {
+        return listOf(this)
+    }
+}
 
-fun PsiDocComment.hasTag(tag: JavadocTag): Boolean =
+internal fun PsiDocComment.hasTag(tag: JavadocTag): Boolean =
     when (tag) {
-        JavadocTag.DESCRIPTION -> descriptionElements.isNotEmpty()
-        else -> findTagByName(tag.toString()) != null
+        DescriptionJavadocTag -> descriptionElements.isNotEmpty()
+        else -> findTagByName(tag.name) != null
     }
 
 fun PsiDocComment.tagsByName(tag: JavadocTag): List<PsiElement> =
     when (tag) {
-        JavadocTag.DESCRIPTION -> descriptionElements.toList()
+        DescriptionJavadocTag -> descriptionElements.toList()
         else -> findTagsByName(tag.toString()).toList()
     }
 
-enum class JavadocTag {
-    PARAM,
-    THROWS,
-    RETURN,
-    AUTHOR,
-    SEE,
-    DEPRECATED,
-    EXCEPTION,
-    HIDE,
-    INCLUDE,
+internal fun PsiElement.getKotlinFqName(): String? = this.kotlinFqNameProp
 
-    /**
-     * Artificial tag created to handle tag-less section
-     */
-    DESCRIPTION,
-    ;
+//// from import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
+internal val PsiElement.kotlinFqNameProp: String?
+    get() = when (val element = this) {
+        is PsiPackage -> element.qualifiedName
+        is PsiClass -> element.qualifiedName
+        is PsiMember -> element.name?.let { name ->
+            val prefix = element.containingClass?.qualifiedName
+            if (prefix != null) "$prefix.$name" else name
+        }
+//        is KtNamedDeclaration -> element.fqName TODO [beresnev] decide what to do with it
+        is PsiQualifiedNamedElement -> element.qualifiedName
+        else -> null
+    }
 
-    override fun toString(): String = super.toString().lowercase()
-
-    /* Missing tags:
-        SERIAL,
-        SERIAL_DATA,
-        SERIAL_FIELD,
-        SINCE,
-        VERSION
-     */
-}
-
-fun PsiClass.implementsInterface(fqName: FqName): Boolean = allInterfaces().any { it.getKotlinFqName() == fqName }
+fun PsiClass.implementsInterface(fqName: FqName): Boolean =
+    allInterfaces().any { it.getKotlinFqName() == fqName.toString() }
 
 fun PsiClass.allInterfaces(): Sequence<PsiClass> =
     sequence {
@@ -244,6 +354,7 @@ fun PsiClass.allInterfaces(): Sequence<PsiClass> =
  * This might be resolved once ultra light classes are enabled for dokka
  * See [KT-39518](https://youtrack.jetbrains.com/issue/KT-39518)
  */
+@OptIn(UnsafeCastFunction::class)
 fun PsiMethod.findSuperMethodsOrEmptyArray(logger: DokkaLogger): Array<PsiMethod> {
     return try {
         /*
@@ -261,16 +372,109 @@ fun PsiMethod.findSuperMethodsOrEmptyArray(logger: DokkaLogger): Array<PsiMethod
             return emptyArray()
         }
         findSuperMethods()
-    } catch (exception: Throwable) {
+    } catch (_: Throwable) {
         logger.warn("Failed to lookup of super methods for ${getKotlinFqName()} (KT-39518)")
         emptyArray()
     }
 }
 
+internal data class KDocContent(
+    val contentTag: KDocTag,
+    val sections: List<KDocSection>
+)
+
+internal fun KtElement.findKDoc(): KDocContent? = this.lookupOwnedKDoc()
+    ?: this.lookupKDocInContainer()
+
+/**
+ * Looks for sections that have a deeply nested [tag],
+ * as opposed to [KDoc.findSectionByTag], which only looks among the top level
+ */
+private fun KDoc.findSectionsContainingTag(tag: KDocKnownTag): List<KDocSection> {
+    return getChildrenOfType<KDocSection>()
+        .filter { it.findTagByName(tag.name.toLowerCaseAsciiOnly()) != null }
+}
+
+private fun KtElement.lookupOwnedKDoc(): KDocContent? {
+    // KDoc for primary constructor is located inside of its class KDoc
+    val psiDeclaration = when (this) {
+        is KtPrimaryConstructor -> getContainingClassOrObject()
+        else -> this
+    }
+
+    if (psiDeclaration is KtDeclaration) {
+        val kdoc = psiDeclaration.docComment
+        if (kdoc != null) {
+            if (this is KtConstructor<*>) {
+                // ConstructorDescriptor resolves to the same JetDeclaration
+                val constructorSection = kdoc.findSectionByTag(KDocKnownTag.CONSTRUCTOR)
+                if (constructorSection != null) {
+                    // if annotated with @constructor tag and the caret is on constructor definition,
+                    // then show @constructor description as the main content, and additional sections
+                    // that contain @param tags (if any), as the most relatable ones
+                    // practical example: val foo = Fo<caret>o("argument") -- show @constructor and @param content
+                    val paramSections = kdoc.findSectionsContainingTag(KDocKnownTag.PARAM)
+                    return KDocContent(constructorSection, paramSections)
+                }
+            }
+            return KDocContent(kdoc.getDefaultSection(), kdoc.getAllSections())
+        }
+    }
+
+    return null
+}
+
+private fun KtElement.lookupKDocInContainer(): KDocContent? {
+    val subjectName = name
+    val containingDeclaration =
+        PsiTreeUtil.findFirstParent(this, true) {
+            it is KtDeclarationWithBody && it !is KtPrimaryConstructor
+                || it is KtClassOrObject
+        }
+
+    val containerKDoc = containingDeclaration?.getChildOfType<KDoc>()
+    if (containerKDoc == null || subjectName == null) return null
+    val propertySection = containerKDoc.findSectionByTag(KDocKnownTag.PROPERTY, subjectName)
+    val paramTag =
+        containerKDoc.findDescendantOfType<KDocTag> { it.knownTag == KDocKnownTag.PARAM && it.getSubjectName() == subjectName }
+
+    val primaryContent = when {
+        // class Foo(val <caret>s: String)
+        this is KtParameter && this.isPropertyParameter() -> propertySection ?: paramTag
+        // fun some(<caret>f: String) || class Some<<caret>T: Base> || Foo(<caret>s = "argument")
+        this is KtParameter || this is KtTypeParameter -> paramTag
+        // if this property is declared separately (outside primary constructor), but it's for some reason
+        // annotated as @property in class's description, instead of having its own KDoc
+        this is KtProperty && containingDeclaration is KtClassOrObject -> propertySection
+        else -> null
+    }
+    return primaryContent?.let {
+        // makes little sense to include any other sections, since we found
+        // documentation for a very specific element, like a property/param
+        KDocContent(it, sections = emptyList())
+    }
+}
+
+object DescriptorKotlinDocCommentCreator : DocCommentCreator {
+    override fun create(element: PsiNamedElement): DocComment? {
+        val ktElement = element.navigationElement as? KtElement ?: return null
+        val kdoc = ktElement.findKDoc() ?: return null
+
+        return KotlinDocComment(kdoc.contentTag, ResolveDocContext(ktElement))
+    }
+}
+
+object JavaDocCommentCreator : DocCommentCreator {
+    override fun create(element: PsiNamedElement): DocComment? {
+        val psiDocComment = (element as? PsiDocCommentOwner)?.docComment ?: return null
+        return JavaDocComment(psiDocComment)
+    }
+}
+
 fun findClosestDocComment(element: PsiNamedElement?, logger: DokkaLogger): DocComment? {
     if (element == null) return null
-    (element as? PsiDocCommentOwner)?.docComment?.run { return@findClosestDocComment JavaDocComment(this) }
-    element.toKdocComment()?.run { return@findClosestDocComment this }
+    JavaDocCommentCreator.create(element)?.run { return this }
+    DescriptorKotlinDocCommentCreator.create(element)?.run { return this }
 
     if (element is PsiMethod) {
         val superMethods = element.findSuperMethodsOrEmptyArray(logger)
@@ -308,21 +512,6 @@ fun findClosestDocComment(element: PsiNamedElement?, logger: DokkaLogger): DocCo
     }
     return element.children.firstIsInstanceOrNull<PsiDocComment>()?.let { JavaDocComment(it) }
 }
-
-fun PsiNamedElement.toKdocComment(): KotlinDocComment? =
-    if (!hasComments()) {
-        null
-    } else {
-        (navigationElement as? KtElement)?.findKDoc {
-            // NOTE: This returns the wrong file if named the same and no comment was found!
-            DescriptorToSourceUtils.descriptorToDeclaration(it)
-        }?.run {
-            KotlinDocComment(
-                comment = this,
-                descriptor = (this@toKdocComment.navigationElement as? KtDeclaration)?.descriptor,
-            )
-        }
-    }
 
 fun PsiDocTag.resolveToElement(): PsiElement? =
     dataElements
@@ -379,9 +568,9 @@ val ImportPath.hasStar: Boolean
     get() = isAllUnder
 
 val DocumentableSource.programmingLanguage: ProgrammingLanguage
-    get() = when (this) {
-        is PsiDocumentableSource -> ProgrammingLanguage.JAVA
-        is DescriptorDocumentableSource -> ProgrammingLanguage.KOTLIN
+    get() = when (this::class.qualifiedName) {
+        PsiDocumentableSource::class.qualifiedName -> ProgrammingLanguage.JAVA
+        "org.jetbrains.dokka.analysis.kotlin.symbols.services.KtPsiDocumentableSource" -> ProgrammingLanguage.KOTLIN
         else -> error("Unknown source type: ${this::class.simpleName}")
     }
 
@@ -487,5 +676,4 @@ fun AnnotationParameterValue.getValue(): Any? =
             },
         )
 
-        else -> error("Could not read Annotation parameter: $this")
     }

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
@@ -2,7 +2,6 @@ package nl.jolanrensen.docProcessor
 
 import com.intellij.openapi.util.TextRange
 import mu.KotlinLogging
-import nl.jolanrensen.docProcessor.ProcessDocsAction.Parameters
 import nl.jolanrensen.docProcessor.gradle.ProcessDocsGradleAction
 import nl.jolanrensen.docProcessor.gradle.lifecycle
 import org.jetbrains.dokka.CoreExtensions
@@ -11,8 +10,6 @@ import org.jetbrains.dokka.DokkaConfigurationImpl
 import org.jetbrains.dokka.DokkaGenerator
 import org.jetbrains.dokka.DokkaSourceSetImpl
 import org.jetbrains.dokka.base.DokkaBase
-import org.jetbrains.dokka.base.translators.descriptors.DefaultDescriptorToDocumentableTranslator
-import org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator
 import org.jetbrains.dokka.model.WithSources
 import org.jetbrains.dokka.model.withDescendants
 import java.io.File
@@ -123,18 +120,9 @@ abstract class ProcessDocsAction {
         // get the sourceToDocumentableTranslators from DokkaBase, both for java and kotlin files
         val context = dokkaGenerator.initializePlugins(configuration, logger, listOf(DokkaBase()))
         val translators = context[CoreExtensions.sourceToDocumentableTranslator]
-            .filter {
-                it is DefaultPsiToDocumentableTranslator ||
-                    // java
-                    it is DefaultDescriptorToDocumentableTranslator // kotlin
-            }
 
-        require(translators.any { it is DefaultPsiToDocumentableTranslator }) {
-            "Could not find DefaultPsiToDocumentableTranslator"
-        }
-
-        require(translators.any { it is DefaultDescriptorToDocumentableTranslator }) {
-            "Could not find DefaultDescriptorToDocumentableTranslator"
+        require(translators.isNotEmpty()) {
+            "Could not find any translators"
         }
 
         // execute the translators on the sources to gather the modules

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/ProcessDocsAction.kt
@@ -109,7 +109,7 @@ abstract class ProcessDocsAction {
                     "debug" -> debug { message }
                     "info" -> info { message }
                     "progress" -> lifecycle { message }
-                    "warn" -> warn { message }
+                    "warn" -> if (!message.startsWith("Couldn't resolve link for")) warn { message }
                     "error" -> error { message }
                     else -> info { message }
                 }
@@ -137,7 +137,6 @@ abstract class ProcessDocsAction {
         val pathsWithoutSources = mutableSetOf<String>()
         val documentables = mutableListOf<DocumentableWrapper>()
         modules.flatMap { it.withDescendants() }.let { rawDocs ->
-            // TODO: issue #12: support Type Aliases
             // TODO: issue #13: support read-only docs
             val (withSources, withoutSources) = rawDocs.partition { it is WithSources }
 

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/gradle/ProcessDocTask.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/gradle/ProcessDocTask.kt
@@ -210,13 +210,12 @@ abstract class ProcessDocTask
         private fun Project.maybeCreateRuntimeConfiguration(): Configuration =
             project.configurations.maybeCreate("kotlinKdocIncludePluginRuntime") {
                 isCanBeConsumed = true
-                val kotlinVersion = "1.8.10"
-                dependencies.add(project.dependencies.create("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"))
-                dependencies.add(
-                    project.dependencies.create("org.jetbrains.dokka:dokka-analysis:$kotlinVersion"),
-                ) // compileOnly in base plugin
-                dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-base:$kotlinVersion"))
-                dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-core:$kotlinVersion"))
+                val dokkaVersion = "2.0.0-Beta"
+
+                dependencies.add(project.dependencies.create("org.jetbrains.dokka:analysis-kotlin-api:$dokkaVersion"))
+                dependencies.add(project.dependencies.create("org.jetbrains.dokka:analysis-kotlin-symbols:$dokkaVersion"))
+                dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-base:$dokkaVersion"))
+                dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-core:$dokkaVersion"))
             }
 
         private fun <T : Any> NamedDomainObjectContainer<T>.maybeCreate(name: String, configuration: T.() -> Unit): T =

--- a/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/gradle/ProcessDocTask.kt
+++ b/doc-processor-gradle-plugin/src/main/kotlin/nl/jolanrensen/docProcessor/gradle/ProcessDocTask.kt
@@ -49,7 +49,7 @@ abstract class ProcessDocTask
         /** Source root folders for preprocessing. This needs to be set! */
         @get:InputFiles
         val sources: ListProperty<File> = factory
-            .listProperty(File::class)
+            .listProperty()
 
         /** Source root folders for preprocessing. This needs to be set! */
         fun sources(files: Iterable<File>): Unit = sources.set(files)
@@ -60,7 +60,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val baseDir: Property<File> = factory
-            .property(File::class)
+            .property<File>()
             .convention(project.projectDir)
 
         /**
@@ -74,7 +74,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val target: Property<File> = factory
-            .property(File::class)
+            .property<File>()
             .convention(File(project.buildDir, "docProcessor${File.separatorChar}${taskIdentity.name}"))
 
         /**
@@ -88,7 +88,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val outputReadOnly: Property<Boolean> = factory
-            .property(Boolean::class)
+            .property<Boolean>()
             .convention(true)
 
         /**
@@ -104,7 +104,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val exportAsHtmlDir: Property<File> = factory
-            .property(File::class)
+            .property<File>()
             .convention(File(target.get(), "htmlExports"))
 
         /**
@@ -120,7 +120,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val htmlOutputReadOnly: Property<Boolean> = factory
-            .property(Boolean::class)
+            .property<Boolean>()
             .convention(true)
 
         /**
@@ -140,7 +140,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val processLimit: Property<Int> = factory
-            .property(Int::class)
+            .property<Int>()
             .convention(10_000)
 
         /**
@@ -162,7 +162,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val processors: ListProperty<String> = factory
-            .listProperty(String::class)
+            .listProperty<String>()
             .convention(
                 listOf(
                     INCLUDE_DOC_PROCESSOR,
@@ -186,7 +186,7 @@ abstract class ProcessDocTask
          */
         @get:Input
         val arguments: MapProperty<String, Any?> = factory
-            .mapProperty(String::class, Any::class)
+            .mapProperty<String, Any>()
             .convention(emptyMap())
 
         /**
@@ -213,7 +213,9 @@ abstract class ProcessDocTask
                 val dokkaVersion = "2.0.0-Beta"
 
                 dependencies.add(project.dependencies.create("org.jetbrains.dokka:analysis-kotlin-api:$dokkaVersion"))
-                dependencies.add(project.dependencies.create("org.jetbrains.dokka:analysis-kotlin-symbols:$dokkaVersion"))
+                dependencies.add(
+                    project.dependencies.create("org.jetbrains.dokka:analysis-kotlin-symbols:$dokkaVersion"),
+                )
                 dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-base:$dokkaVersion"))
                 dependencies.add(project.dependencies.create("org.jetbrains.dokka:dokka-core:$dokkaVersion"))
             }
@@ -320,6 +322,7 @@ abstract class ProcessDocTask
                 sourceRoots.forEach {
                     if (it.exists()) sourceRoot(it)
                 }
+                apiVersion.set("2.0")
             }.build()
 
             val workQueue = workerExecutor.classLoaderIsolation {


### PR DESCRIPTION
Fixes https://github.com/Jolanrensen/docProcessorGradlePlugin/issues/52
Fixes https://github.com/Jolanrensen/docProcessorGradlePlugin/issues/12 thanks Dokka :D

I looked into the Kotin Analysis API, but it seems to [not be ready yet](https://kotlin.github.io/analysis-api/index_md.html#using-in-command-line-tools) for use outside of IntelliJ Plugins. Dokka 2.0.0 wraps the Analysis API and can run from Gradle, so it seems it's worth it to continue our Dokka dependency for a while.
This PR bumps to Dokka 2.0.0-Beta (with the 2.0 version being released soon I believe).

I didn't make an attempt to support Kotlin below 2.0 since we personally have no need for it, but in theory it shouldn't matter, as our Gradle build can simply run in K2 mode.