### PR TITLE
adds contextual sources support

### DIFF
--- a/kodex-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/kodex/DocProcessorFunctionalTest.kt
+++ b/kodex-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/kodex/DocProcessorFunctionalTest.kt
@@ -91,7 +91,11 @@ abstract class DocProcessorFunctionalTest(name: String) {
         """.trimIndent()
 
     @Language("kts")
-    private fun getBuildFileContent(processors: List<String>, plugins: List<String>): String =
+    private fun getBuildFileContent(
+        processors: List<String>,
+        plugins: List<String>,
+        contextualSourceSets: List<String>,
+    ): String =
         """
         import nl.jolanrensen.kodex.gradle.*
         import nl.jolanrensen.kodex.defaultProcessors.*
@@ -108,6 +112,7 @@ abstract class DocProcessorFunctionalTest(name: String) {
         kodex {
             preprocess(kotlin.sourceSets.main) {
                 processors = listOf(${processors.joinToString()})
+                contextualSourceSets(${contextualSourceSets.joinToString()})
                 dependencies {
                 ${
             if (plugins.isEmpty()) {
@@ -178,9 +183,14 @@ abstract class DocProcessorFunctionalTest(name: String) {
         processors: List<String>,
         plugins: List<String> = emptyList(),
         additionals: List<Additional> = emptyList(),
+        contextualSourceSets: List<String> = emptyList(),
         buildScan: Boolean = false,
     ): String {
-        initializeProjectFiles(processors = processors, plugins = plugins)
+        initializeProjectFiles(
+            processors = processors,
+            plugins = plugins,
+            contextualSourceSets = contextualSourceSets,
+        )
         writeAdditionalFiles(additionals)
 
         // Get source- and destination directories based on the package name
@@ -202,7 +212,11 @@ abstract class DocProcessorFunctionalTest(name: String) {
     /**
      * Clears the project directory and creates the build files.
      */
-    private fun initializeProjectFiles(processors: List<String>, plugins: List<String> = emptyList()) {
+    private fun initializeProjectFiles(
+        processors: List<String>,
+        plugins: List<String> = emptyList(),
+        contextualSourceSets: List<String>,
+    ) {
         // Set up the test build
         projectDirectory.deleteRecursively()
         projectDirectory.mkdirs()
@@ -214,7 +228,7 @@ abstract class DocProcessorFunctionalTest(name: String) {
             .write(propertiesFile)
 
         File(projectDirectory, "build.gradle.kts")
-            .write(getBuildFileContent(processors, plugins))
+            .write(getBuildFileContent(processors, plugins, contextualSourceSets))
     }
 
     /**

--- a/kodex-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/kodex/TestContextual.kt
+++ b/kodex-gradle-plugin/src/functionalTest/kotlin/nl/jolanrensen/kodex/TestContextual.kt
@@ -1,0 +1,65 @@
+package nl.jolanrensen.kodex
+
+import io.kotest.matchers.shouldBe
+import nl.jolanrensen.kodex.defaultProcessors.INCLUDE_DOC_PROCESSOR
+import nl.jolanrensen.kodex.defaultProcessors.REMOVE_ESCAPE_CHARS_PROCESSOR
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class TestContextual : DocProcessorFunctionalTest(name = "contextual") {
+
+    private val processors = listOf(
+        ::INCLUDE_DOC_PROCESSOR,
+        ::REMOVE_ESCAPE_CHARS_PROCESSOR,
+    ).map { it.name }
+
+    @Test
+    fun `contextual sourceSet`() {
+        @Language("kt")
+        val testContent = """
+            package com.example.plugin.tests
+            
+            /** ! */
+            interface A
+            
+            /**
+             * Hello World{@include [A]}
+             */
+            fun helloWorld() {}
+        """.trimIndent()
+
+        // added by including the `test` SourceSet
+        val testFile = AdditionalFile(
+            relativePath = "src/test/kotlin/com/example/plugin/tests/Test2.kt",
+            content = testContent,
+        )
+
+        @Language("kt")
+        val content = """
+            package com.example.plugin
+            
+            /**
+             * @include [com.example.plugin.tests.helloWorld]
+             */
+            fun helloWorld2() {}
+        """.trimIndent()
+
+        @Language("kt")
+        val expectedOutput = """
+            package com.example.plugin
+            
+            /**
+             * Hello World!
+             */
+            fun helloWorld2() {}
+        """.trimIndent()
+
+        processContent(
+            content = content,
+            packageName = "com.example.plugin",
+            processors = processors,
+            contextualSourceSets = listOf("kotlin.sourceSets.test.get()"),
+            additionals = listOf(testFile),
+        ) shouldBe expectedOutput
+    }
+}

--- a/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/RunKodexAction.kt
+++ b/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/RunKodexAction.kt
@@ -59,6 +59,7 @@ abstract class RunKodexAction {
     data class SourceSetSpec(
         val name: String,
         val sourceRoots: List<File>,
+        val contextualSourceSets: List<SourceSetSpec>,
         val languageVersion: String?,
         val apiVersion: String?,
         val analysisPlatform: String?, // uses org.jetbrains.dokka.Platform values
@@ -82,23 +83,32 @@ abstract class RunKodexAction {
 
     abstract val parameters: Parameters
 
-    val sources by lazy {
-        parameters.sources.let {
-            DokkaSourceSetImpl(
-                sourceSetID = DokkaSourceSetID(it.moduleName, it.name),
-                classpath = it.classpath,
-                displayName = it.name,
-                sourceRoots = it.sourceRoots.toSet(),
-                skipEmptyPackages = false,
-                skipDeprecated = false,
-                documentedVisibilities = DokkaConfiguration.Visibility.entries.toSet(),
-                includeNonPublic = true,
-                analysisPlatform = it.analysisPlatform?.let { Platform.fromString(it) } ?: Platform.DEFAULT,
-                languageVersion = it.languageVersion,
-                apiVersion = it.apiVersion,
-            )
-        }
+    val sources: DokkaSourceSetImpl by lazy {
+        parameters.sources.toDokka()
     }
+
+    // filled by `sources`
+    val contextualSources: MutableSet<DokkaSourceSetImpl> = mutableSetOf()
+
+    private fun SourceSetSpec.toDokka(): DokkaSourceSetImpl =
+        DokkaSourceSetImpl(
+            sourceSetID = DokkaSourceSetID(moduleName, name),
+            classpath = classpath,
+            displayName = name,
+            dependentSourceSets = contextualSourceSets.map {
+                it.toDokka()
+                    .also { contextualSources += it }
+                    .sourceSetID
+            }.toSet(),
+            sourceRoots = sourceRoots.toSet(),
+            skipEmptyPackages = false,
+            skipDeprecated = false,
+            documentedVisibilities = DokkaConfiguration.Visibility.entries.toSet(),
+            includeNonPublic = true,
+            analysisPlatform = analysisPlatform?.let { Platform.fromString(it) } ?: Platform.DEFAULT,
+            languageVersion = languageVersion,
+            apiVersion = apiVersion,
+        )
 
     protected suspend fun process() {
         // analyse the sources with dokka to get the documentables
@@ -151,10 +161,9 @@ abstract class RunKodexAction {
     }
 
     private fun analyseSourcesWithDokka(): (List<DocProcessor>) -> DocumentablesByPath {
+        val allSources = listOf(sources, *contextualSources.toTypedArray())
         // initialize dokka with the sources
-        val configuration = DokkaConfigurationImpl(
-            sourceSets = listOf(sources),
-        )
+        val configuration = DokkaConfigurationImpl(sourceSets = allSources)
         val logger = DokkaBootstrapImpl.DokkaProxyLogger { level, message ->
             with(log) {
                 when (level) {
@@ -184,11 +193,19 @@ abstract class RunKodexAction {
                 context = context,
             )
         }
+        val contextualModules = contextualSources.flatMap { src ->
+            translators.map {
+                it.invoke(
+                    sourceSet = src,
+                    context = context,
+                )
+            }
+        }
 
         // collect the right documentables from the modules (only linkable elements with docs)
         val pathsWithoutSources = mutableSetOf<String>()
         val documentables = mutableListOf<DocumentableWrapper>()
-        modules.flatMap { it.withDescendants() }.let { rawDocs ->
+        (modules + contextualModules).flatMap { it.withDescendants() }.let { rawDocs ->
             // TODO: issue #13: support read-only docs
             val (withSources, withoutSources) = rawDocs.partition { it is WithSources }
 
@@ -196,12 +213,14 @@ abstract class RunKodexAction {
             pathsWithoutSources += withoutSources.map { it.dri.fullyQualifiedPath }
             pathsWithoutSources += withoutSources.mapNotNull { it.dri.fullyQualifiedExtensionPath }
 
-            documentables += withSources.mapNotNull {
-                val source = (it as WithSources).sources[sources]
-                    ?: return@mapNotNull null
+            documentables += withSources.mapNotNull { doc ->
+                val source =
+                    allSources.firstNotNullOfOrNull { src ->
+                        (doc as WithSources).sources[src]
+                    } ?: return@mapNotNull null
 
                 DocumentableWrapper.createFromDokkaOrNull(
-                    documentable = it,
+                    documentable = doc,
                     source = source,
                     logger = logger,
                 )

--- a/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/gradle/KodexPlugin.kt
+++ b/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/gradle/KodexPlugin.kt
@@ -66,6 +66,7 @@ class KodexPlugin : Plugin<Project> {
         kotlinExtension: KotlinProjectExtension,
     ) {
         val inputSourceSet = taskCreator.inputSourceSet.get()
+        val contextualSourceSets = taskCreator.contextualSourceSets.get()
         val sourceSetName = taskCreator.newSourceSetName.get()
         val taskName = taskCreator.taskName.get()
 
@@ -75,6 +76,9 @@ class KodexPlugin : Plugin<Project> {
         ) {
             group = "KoDEx"
             description = "Runs KoDEx $sourceSetName on the ${inputSourceSet.name} sources"
+            contextualSources.set(
+                contextualSourceSets.map { it.kotlin.sourceDirectories.toList() }
+            )
             applyPropertiesFrom(taskCreator)
             taskCreator.runOnTask.get().forEach {
                 it.execute(this)

--- a/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/gradle/KodexSourceSetTaskBuilder.kt
+++ b/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/gradle/KodexSourceSetTaskBuilder.kt
@@ -5,83 +5,97 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.setProperty
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import javax.inject.Inject
 
 abstract class KodexSourceSetTaskBuilder
-    @Inject
-    constructor(
-        sourceSetName: String,
-        factory: ObjectFactory,
-        project: Project,
-    ) : CommonKodexTaskProperties {
+@Inject
+constructor(
+    sourceSetName: String,
+    factory: ObjectFactory,
+    project: Project,
+) : CommonKodexTaskProperties {
 
-        init {
-            applyConventions(project, factory, sourceSetName)
-        }
-
-        @get:Input
-        internal val inputSourceSet: Property<KotlinSourceSet> = factory.property<KotlinSourceSet>()
-
-        @get:Input
-        val isMainSourceSet: Property<Boolean> = factory.property<Boolean>()
-            .convention(inputSourceSet.map { it.name == "main" })
-
-        fun isMainSourceSet(boolean: Boolean): Unit = isMainSourceSet.set(boolean)
-
-        @get:Input
-        val newSourceSetName: Property<String> = factory.property<String>()
-            .convention(inputSourceSet.map { it.name + "Kodex" })
-
-        fun newSourceSetName(string: String): Unit = newSourceSetName.set(string)
-
-        @get:Input
-        val taskName: Property<String> = factory.property<String>()
-            .convention(
-                newSourceSetName.map { "preprocess${it.replaceFirstChar { it.titlecase() }}" },
-            )
-
-        fun taskName(string: String): Unit = taskName.set(string)
-
-        /**
-         * Whether to generate a jar file for the KoDEx-processed source set.
-         *
-         * Creates the Gradle task "kodex${sourceSetName}Jar" if true.
-         *
-         * Defaults to true for the main source set.
-         *
-         * NOTE: This does not yet work for multiplatform projects, set it to `false` for now.
-         */
-        @get:Input
-        val generateJar: Property<Boolean> = factory.property<Boolean>()
-            .convention(isMainSourceSet)
-
-        fun generateJar(boolean: Boolean): Unit = generateJar.set(boolean)
-
-        /**
-         * Whether to generate a sources jar file for the KoDEx-processed source set.
-         *
-         * Creates the Gradle task "kodex${sourceSetName}SourcesJar" if true.
-         *
-         * Defaults to true for the main source set.
-         *
-         * NOTE: This does not yet work for multiplatform projects, set it to `false` for now.
-         */
-        @get:Input
-        val generateSourcesJar: Property<Boolean> = factory.property<Boolean>()
-            .convention(isMainSourceSet)
-
-        fun generateSourcesJar(boolean: Boolean): Unit = generateSourcesJar.set(boolean)
-
-        @get:Internal
-        internal val runOnTask: ListProperty<Action<RunKodexTask>> = factory.listProperty<Action<RunKodexTask>>()
-            .convention(listOf())
-
-        fun task(action: Action<RunKodexTask>) {
-            runOnTask.add(action)
-        }
+    init {
+        applyConventions(project, factory, sourceSetName)
     }
+
+    @get:Input
+    internal val inputSourceSet: Property<KotlinSourceSet> = factory.property<KotlinSourceSet>()
+
+    @get:Input
+    val isMainSourceSet: Property<Boolean> = factory.property<Boolean>()
+        .convention(inputSourceSet.map { it.name == "main" })
+
+    fun isMainSourceSet(boolean: Boolean): Unit = isMainSourceSet.set(boolean)
+
+    @get:Input
+    val newSourceSetName: Property<String> = factory.property<String>()
+        .convention(inputSourceSet.map { it.name + "Kodex" })
+
+    fun newSourceSetName(string: String): Unit = newSourceSetName.set(string)
+
+    @get:Input
+    val contextualSourceSets: SetProperty<KotlinSourceSet> = factory.setProperty<KotlinSourceSet>()
+        .convention(emptySet())
+
+    fun contextualSourceSets(sourceSets: Iterable<KotlinSourceSet>): Unit =
+        contextualSourceSets.addAll(sourceSets)
+
+    fun contextualSourceSets(first: KotlinSourceSet, vararg others: KotlinSourceSet): Unit {
+        contextualSourceSets.add(first)
+        contextualSourceSets.addAll(*others)
+    }
+
+    @get:Input
+    val taskName: Property<String> = factory.property<String>()
+        .convention(
+            newSourceSetName.map { "preprocess${it.replaceFirstChar { it.titlecase() }}" },
+        )
+
+    fun taskName(string: String): Unit = taskName.set(string)
+
+    /**
+     * Whether to generate a jar file for the KoDEx-processed source set.
+     *
+     * Creates the Gradle task "kodex${sourceSetName}Jar" if true.
+     *
+     * Defaults to true for the main source set.
+     *
+     * NOTE: This does not yet work for multiplatform projects, set it to `false` for now.
+     */
+    @get:Input
+    val generateJar: Property<Boolean> = factory.property<Boolean>()
+        .convention(isMainSourceSet)
+
+    fun generateJar(boolean: Boolean): Unit = generateJar.set(boolean)
+
+    /**
+     * Whether to generate a sources jar file for the KoDEx-processed source set.
+     *
+     * Creates the Gradle task "kodex${sourceSetName}SourcesJar" if true.
+     *
+     * Defaults to true for the main source set.
+     *
+     * NOTE: This does not yet work for multiplatform projects, set it to `false` for now.
+     */
+    @get:Input
+    val generateSourcesJar: Property<Boolean> = factory.property<Boolean>()
+        .convention(isMainSourceSet)
+
+    fun generateSourcesJar(boolean: Boolean): Unit = generateSourcesJar.set(boolean)
+
+    @get:Internal
+    internal val runOnTask: ListProperty<Action<RunKodexTask>> = factory.listProperty<Action<RunKodexTask>>()
+        .convention(listOf())
+
+    fun task(action: Action<RunKodexTask>) {
+        runOnTask.add(action)
+    }
+}

--- a/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/gradle/RunKodexTask.kt
+++ b/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/gradle/RunKodexTask.kt
@@ -46,6 +46,15 @@ abstract class RunKodexTask
         /** Source root folders for preprocessing. This needs to be set! */
         fun sources(files: Iterable<File>): Unit = sources.set(files)
 
+        /** Source root folders for preprocessing. */
+        @get:InputFiles
+        val contextualSources: ListProperty<List<File>> = factory
+            .listProperty<List<File>>()
+            .convention(emptyList())
+
+        /** Source root folders for preprocessing. */
+        fun contextualSources(files: Iterable<List<File>>): Unit = contextualSources.addAll(files)
+
         /**
          * Set base directory which will be used for relative source paths.
          * By default, it is '$projectDir'.
@@ -116,6 +125,7 @@ abstract class RunKodexTask
             log.lifecycle { "Kodex is running!" }
 
             val sourceRoots = sources.get()
+            val contextualSourceRoots = contextualSources.get()
             val target = target.get()
             val runtime = classpath.get() // .resolve()
             val processors = processors.get()
@@ -127,6 +137,7 @@ abstract class RunKodexTask
 
             log.info { "Using target folder: $target" }
             log.info { "Using source folders: $sourceRoots" }
+            log.info { "Using contextual source folders: $contextualSourceRoots" }
             log.info { "Using target folders: ${targets.files.toList()}" }
             log.info { "Using runtime classpath: ${runtime.joinToString("\n")}" }
 
@@ -134,6 +145,17 @@ abstract class RunKodexTask
             val sourceSetSpec = RunKodexAction.SourceSetSpec(
                 name = sourceSetName,
                 sourceRoots = sourceRoots.filter { it.exists() },
+                contextualSourceSets = contextualSourceRoots.mapIndexed { i, it ->
+                    RunKodexAction.SourceSetSpec(
+                        name = "contextualSourceSet$i",
+                        sourceRoots = it,
+                        contextualSourceSets = emptyList(),
+                        languageVersion = languageVersion.getOrNull(),
+                        apiVersion = apiVersion.getOrNull(),
+                        analysisPlatform = analysisPlatform.getOrNull(),
+                        classpath = projectClassPath.get(),
+                    )
+                },
                 languageVersion = languageVersion.getOrNull(),
                 apiVersion = apiVersion.getOrNull(),
                 analysisPlatform = analysisPlatform.getOrNull(),


### PR DESCRIPTION
Allows additional sources to be specified that should be treated as context of the main source, but will not produce modified files. This can be useful for referencing across modules (though, careful of speed decreases).

Try it in:

```kts
kodex {
    preprocess(sourceSet) {
        contextualSourceSets = setOf(otherSourceSet)
    }
}
```

or
```kts
val processKDocsMain by tasks.registering(RunKodexTask::class) {
    ...
    contextualSources = listOf(otherSourceSet.sourceDirectories.toList())
}
```